### PR TITLE
allow init script to work with environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ On Rails:
     ```ruby
     # Iodine setup - use conditional setup to allow command-line arguments to override these:
     if(defined?(Iodine))
-      Iodine.threads ||= ENV.fetch("RAILS_MAX_THREADS") { 5 }
-      Iodine.workers ||= ENV.fetch("WEB_CONCURRENCY") { 2 }
+      Iodine.threads = ENV.fetch("RAILS_MAX_THREADS") { 5 } if Iodine.threads.zero?
+      Iodine.workers = ENV.fetch("WEB_CONCURRENCY") { 2 } if Iodine.workers.zero?
       Iodine::DEFAULT_SETTINGS[:port] = ENV.fetch("PORT") if ENV.fetch("PORT")
     end
     ```


### PR DESCRIPTION
I saw on the documentation that the initializer uses "||=" to allow command-line arguments to overwrite `Iodine.threads` and `Iodine.workers`. However, when I tested here I realized that when this arguments are not provided they default to 0 instead of `nil`. Hence `||=` doesn't work in this case.

So I made a tweak to the `Readme.md` to fix that.