### PR TITLE
Fix TypeError when using enviroment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ On Rails:
     ```ruby
     # Iodine setup - use conditional setup to allow command-line arguments to override these:
     if(defined?(Iodine))
-      Iodine.threads = ENV.fetch("RAILS_MAX_THREADS") { 5 } if Iodine.threads.zero?
-      Iodine.workers = ENV.fetch("WEB_CONCURRENCY") { 2 } if Iodine.workers.zero?
+      Iodine.threads = ENV.fetch("RAILS_MAX_THREADS", 5).to_i if Iodine.threads.zero?
+      Iodine.workers = ENV.fetch("WEB_CONCURRENCY", 2).to_i if Iodine.workers.zero?
       Iodine::DEFAULT_SETTINGS[:port] = ENV.fetch("PORT") if ENV.fetch("PORT")
     end
     ```


### PR DESCRIPTION
Since environment variables are parsed as _string_, there is a TypeError when configuring Iodine like this:
```ruby
# Iodine setup - use conditional setup to allow command-line arguments to override these:
Iodine.threads = ENV.fetch("RAILS_MAX_THREADS") { 5 } if Iodine.threads.zero?
Iodine.workers = ENV.fetch("WEB_CONCURRENCY") { 1 } if Iodine.workers.zero?
```
```sh
config/initializers/iodine.rb:3:in `workers=': wrong argument type String (expected Fixnum) (TypeError)
```

In order to fix that the environment variables should be cast to integers.