### PR TITLE
Fix listen host key name in options Hash

### DIFF
--- a/lib/rack/handler/iodine.rb
+++ b/lib/rack/handler/iodine.rb
@@ -7,7 +7,7 @@ module Iodine
     # Runs a Rack app, as par the Rack handler requirements.
     def self.run(app, options = {})
       # nested applications... is that a thing?
-      Iodine.listen(service: :http, handler: app, port: options[:Port], address: options[:Address])
+      Iodine.listen(service: :http, handler: app, port: options[:Port], address: options[:Host])
 
       # start Iodine
       Iodine.start


### PR DESCRIPTION
`Rack::Server` passes the listen host as `:Host` and not `:Address`.

https://www.rubydoc.info/gems/rack/Rack%2FServer:initialize