### PR TITLE
Mitigate undefined MAP_ANONYMOUS on MacOS <= 10.10

### DIFF
--- a/ext/iodine/fio.c
+++ b/ext/iodine/fio.c
@@ -90,6 +90,13 @@ Feel free to copy, use and enjoy according to the license provided.
 #define FIO_TLS_WEAK __attribute__((weak))
 #endif
 
+/* Mitigates MAP_ANONYMOUS not being defined on older versions of MacOS */
+#if !defined(MAP_ANONYMOUS)
+  #if defined(MAP_ANON)
+    #define MAP_ANONYMOUS MAP_ANON
+  #endif
+#endif
+
 /* *****************************************************************************
 Event deferring (declarations)
 ***************************************************************************** */


### PR DESCRIPTION
On versions of MacOS 10.10 and older, `MAP_ANONYMOUS` is undefined.

This PR simply aliases `MAP_ANONYMOUS` to `MAP_ANON` in this case.