### PR TITLE
Only set iodine as default handler if ENV['RACK_HANDLER'] is not set

### DIFF
--- a/lib/rack/handler/iodine.rb
+++ b/lib/rack/handler/iodine.rb
@@ -18,14 +18,7 @@ module Iodine
   end
 end
 
-ENV['RACK_HANDLER'] = 'iodine'
-
-# make Iodine the default fallback position for Rack.
-begin
-  require 'rack/handler' unless defined?(Rack::Handler)
-  Rack::Handler::WEBrick = ::Iodine::Rack # Rack::Handler.get(:iodine)
-rescue LoadError
-end
+ENV['RACK_HANDLER'] ||= 'iodine'
 
 begin
   ::Rack::Handler.register('iodine', 'Iodine::Rack') if defined?(::Rack::Handler)


### PR DESCRIPTION
Rack appears to use this env var before selecting from a final list as per these docs https://www.rubydoc.info/gems/rack/Rack/Handler#default-class_method

Solves #80 