### PR TITLE
Windows port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 /old_stuff/
 *.bundle
 *.so
+*.gem
 
 .ruby-version
 .clang_complete

--- a/exe/iodine.bat
+++ b/exe/iodine.bat
@@ -1,0 +1,2 @@
+@ECHO OFF
+@"ruby.exe" "%~dpn0" %*

--- a/exe/iodine.bat
+++ b/exe/iodine.bat
@@ -1,2 +1,0 @@
-@ECHO OFF
-@"ruby.exe" "%~dpn0" %*

--- a/ext/iodine/fio.c
+++ b/ext/iodine/fio.c
@@ -870,7 +870,7 @@ static pthread_once_t fio_thread_data_once = PTHREAD_ONCE_INIT;
 static void init_fio_thread_data_key(void) {
   pthread_key_create(&fio_thread_data_key, free);
 }
-static void init_fio_thread_data(void) {
+static void init_fio_thread_data_ptr(void) {
   fio_thread_queue_s *fio_thread_data = malloc(sizeof(fio_thread_queue_s));
   FIO_ASSERT_ALLOC(fio_thread_data);
   memset(fio_thread_data, 0, sizeof(fio_thread_queue_s));
@@ -884,10 +884,10 @@ static void init_fio_thread_data(void) {
 }
 
 FIO_FUNC inline void fio_thread_make_suspendable(void) {
-  pthread_once(&fio_thread_data_once, init_fio_thread_data);
+  pthread_once(&fio_thread_data_once, init_fio_thread_data_key);
   fio_thread_queue_s *fio_thread_data = (fio_thread_queue_s *)pthread_getspecific(fio_thread_data_key);
   if (!fio_thread_data) {
-    init_fio_thread_data();
+    init_fio_thread_data_ptr();
     fio_thread_data = (fio_thread_queue_s *)pthread_getspecific(fio_thread_data_key);
   }
 #ifdef __MINGW32__

--- a/ext/iodine/fio.c
+++ b/ext/iodine/fio.c
@@ -132,6 +132,18 @@ Windows support functions
 #define WIFEXITED(s)	(!((s)&0xFF))
 #define WEXITSTATUS(s)	(((s)>>8)&0xFF)
 
+FARPROC accept_ptr;
+FARPROC bind_ptr;
+FARPROC closesocket_ptr;
+FARPROC connect_ptr;
+FARPROC getsockopt_ptr;
+FARPROC ioctlsocket_ptr;
+FARPROC listen_ptr;
+FARPROC recv_ptr;
+FARPROC send_ptr;
+FARPROC setsockopt_ptr;
+FARPROC socket_ptr;
+
 int fork() {
   fprintf(stderr, "fork() is not supported on Windows.\n");
   errno = ENOSYS;

--- a/ext/iodine/fio.c
+++ b/ext/iodine/fio.c
@@ -2889,6 +2889,10 @@ int fio_fd4handle(SOCKET handle) {
   return -1;
 }
 
+SOCKET fio_handle4fd(unsigned int fd) {
+  return fd_data(fd).socket_handle;
+}
+
 void fio_clear_handle(int fd) {
   fio_lock(&(fd_data(fd).sock_lock));
   fd_data(fd).socket_handle = INVALID_SOCKET;

--- a/ext/iodine/fio.c
+++ b/ext/iodine/fio.c
@@ -867,6 +867,7 @@ static pthread_once_t fio_thread_data_once = PTHREAD_ONCE_INIT;
 static void init_fio_thread_data(void) {
   fio_thread_queue_s *fio_thread_data = malloc(sizeof(fio_thread_queue_s));
   FIO_ASSERT(fio_thread_data);
+  memset(fio_thread_data, 0, sizeof(fio_thread_queue_s));
 #ifdef __MINGW32__
   fio_thread_data->handle = INVALID_HANDLE_VALUE;
 #else
@@ -900,6 +901,7 @@ FIO_FUNC inline void fio_thread_make_suspendable(void) {
 }
 
 FIO_FUNC inline void fio_thread_cleanup(void) {
+  pthread_once(&fio_thread_data_once, init_fio_thread_data);
   fio_thread_queue_s fio_thread_data = *(fio_thread_queue_s *)pthread_getspecific(fio_thread_data_key);
 #ifdef __MINGW32__
   HANDLE h = fio_thread_data.handle;
@@ -917,6 +919,7 @@ FIO_FUNC inline void fio_thread_cleanup(void) {
 
 /* suspend thread execution (might be resumed unexpectedly) */
 FIO_FUNC void fio_thread_suspend(void) {
+  pthread_once(&fio_thread_data_once, init_fio_thread_data);
   fio_thread_queue_s fio_thread_data = *(fio_thread_queue_s *)pthread_getspecific(fio_thread_data_key);
 #ifdef __MINGW32__
   fio_lock(&fio_thread_lock);
@@ -8285,8 +8288,10 @@ static pthread_once_t s_c_once = PTHREAD_ONCE_INIT;
 static void init_s_c_key(void) {
   uint64_t *s = malloc(sizeof(uint64_t) * 2);
   FIO_ASSERT_ALLOC(s);
+  memset(s, 0, sizeof(uint64_t) * 2);
   uint16_t *c = malloc(sizeof(uint16_t));
   FIO_ASSERT_ALLOC(c);
+  memset(c, 0, sizeof(uint16_t));
   pthread_key_create(&s_key, free);
   pthread_key_create(&c_key, free);
 }

--- a/ext/iodine/fio.c
+++ b/ext/iodine/fio.c
@@ -938,7 +938,7 @@ FIO_FUNC void fio_thread_suspend(void) {
     fio_thread_data->in_list = 1;
   }
   fio_unlock(&fio_thread_lock);
-  WaitForSingleObject(fio_thread_data->handle, INFINITE);
+  WaitForSingleObject(fio_thread_data->handle, 500);
 #else
   fio_lock(&fio_thread_lock);
   fio_ls_embd_push(&fio_thread_queue, &fio_thread_data->node);
@@ -3293,7 +3293,7 @@ static void fio_sock_perform_close_fd(intptr_t fd) {
   fio_clear_handle(fd);
   if (osffd != -1) {
     _close(osffd);
-  } else {
+  } else if (s != -1) {
     closesocket_ptr(s);
   }
 }
@@ -4562,9 +4562,8 @@ static void fio_worker_cleanup(void) {
   while (0 < end && fio_data->poll[end-1].fd == (SOCKET)-1)
     --end;
   for (size_t i = 0; i <= fio_data->capa; ++i) {
-    if (fd_data(i).protocol || fd_data(i).open) {
-      fio_force_close(fd2uuid(i));
-    }
+    // ensure _all_ socket handles and fds are closed for good
+    fio_force_close(fd2uuid(i));
   }
 #else
   for (size_t i = 0; i <= fio_data->max_protocol_fd; ++i) {

--- a/ext/iodine/fio.c
+++ b/ext/iodine/fio.c
@@ -1701,7 +1701,10 @@ static void sig_int_handler(int sig) {
   default:
     break;
   }
-#ifndef __MINGW32__
+#ifdef __MINGW32__
+  if (old)
+    fio_old_sig_int(sig);
+#else
   /* propagate signale handling to previous existing handler (if any) */
   if (old && old->sa_handler != SIG_IGN && old->sa_handler != SIG_DFL)
     old->sa_handler(sig);

--- a/ext/iodine/fio.c
+++ b/ext/iodine/fio.c
@@ -7928,7 +7928,7 @@ static inline arena_s *arena_lock(arena_s *preffered) {
 
 static pthread_key_t arena_last_used_key;
 static pthread_once_t arena_last_used_once;
-static_void init_arena_last_used_key(void) {
+static void init_arena_last_used_key(void) {
   pthread_key_create(&arena_last_used_key, NULL);
 }
 

--- a/ext/iodine/fio.c
+++ b/ext/iodine/fio.c
@@ -878,7 +878,7 @@ static void init_fio_thread_data_ptr(void) {
   fio_thread_data->handle = INVALID_HANDLE_VALUE;
 #else
   fio_thread_data->fd_wait = -1;
-  fio_thread_data->fd_signal = -1};
+  fio_thread_data->fd_signal = -1;
 #endif
   pthread_setspecific(fio_thread_data_key, fio_thread_data);
 }

--- a/ext/iodine/fio.c
+++ b/ext/iodine/fio.c
@@ -4,6 +4,11 @@ License: MIT
 
 Feel free to copy, use and enjoy according to the license provided.
 ***************************************************************************** */
+#ifdef __MINGW32__
+#define FD_SETSIZE 1024
+#define FIO_FORCE_MALLOC 1
+#define FIO_DISABLE_HOT_RESTART 1
+#endif
 
 #include <fio.h>
 
@@ -18,9 +23,12 @@ Feel free to copy, use and enjoy according to the license provided.
 #include <errno.h>
 #include <limits.h>
 #include <pthread.h>
+#ifndef __MINGW32__
 #include <sys/mman.h>
+#endif
 #include <unistd.h>
 
+#ifndef __MINGW32__
 #include <netdb.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
@@ -29,12 +37,27 @@ Feel free to copy, use and enjoy according to the license provided.
 #include <sys/ioctl.h>
 #include <sys/resource.h>
 #include <sys/socket.h>
+#endif
 #include <sys/stat.h>
 #include <sys/types.h>
+#ifndef __MINGW32__
 #include <sys/un.h>
 #include <sys/wait.h>
 
 #include <arpa/inet.h>
+#endif
+
+#ifdef __MINGW32__
+#include <windef.h>
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#endif
+
+#if HAVE_OPENSSL
+#include <openssl/bio.h>
+#include <openssl/err.h>
+#include <openssl/ssl.h>
+#endif
 
 #if HAVE_OPENSSL
 #include <openssl/bio.h>
@@ -47,12 +70,14 @@ Feel free to copy, use and enjoy according to the license provided.
 #define FIO_ENGINE_POLL 0
 #endif
 
-#if !FIO_ENGINE_POLL && !FIO_ENGINE_EPOLL && !FIO_ENGINE_KQUEUE
+#if !FIO_ENGINE_POLL && !FIO_ENGINE_EPOLL && !FIO_ENGINE_KQUEUE && !FIO_ENGINE_WSAPOLL
 #if defined(__linux__)
 #define FIO_ENGINE_EPOLL 1
 #elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) ||     \
     defined(__OpenBSD__) || defined(__bsdi__) || defined(__DragonFly__)
 #define FIO_ENGINE_KQUEUE 1
+#elif defined(__MINGW32__)
+#define FIO_ENGINE_WSAPOLL 1
 #else
 #define FIO_ENGINE_POLL 1
 #endif
@@ -68,7 +93,9 @@ Feel free to copy, use and enjoy according to the license provided.
 #endif
 
 #ifndef FIO_USE_URGENT_QUEUE
+#ifndef __MINGW32__
 #define FIO_USE_URGENT_QUEUE 1
+#endif
 #endif
 
 #ifndef DEBUG_SPINLOCK
@@ -95,6 +122,150 @@ Feel free to copy, use and enjoy according to the license provided.
 #else
 #define MAP_ANONYMOUS 0
 #endif
+#endif
+
+/* *****************************************************************************
+Windows support functions
+***************************************************************************** */
+#ifdef __MINGW32__
+
+#define WIFEXITED(s)	(!((s)&0xFF))
+#define WEXITSTATUS(s)	(((s)>>8)&0xFF)
+
+int fork() {
+  fprintf(stderr, "fork() is not supported on Windows.\n");
+  errno = ENOSYS;
+  return -1;
+}
+
+int ioctl (int fd, u_long request, int* argp) {
+  int error;
+  u_long flags;
+  flags = *argp;
+  error = ioctlsocket(fd, request, &flags);
+  if (error > 0) { return -1; }
+  else { return 0; }
+}
+
+int kill(int pid, int sig) {
+  /* Credit to Jan Biedermann (GitHub: @janbiedermann) */
+  HANDLE handle;
+  DWORD status;
+  if (sig < 0 || sig >= NSIG) {
+    errno = EINVAL;
+    return -1;
+  }
+#ifdef SIGCONT
+  if (sig == SIGCONT) {
+    errno = ENOSYS;
+    return -1;
+  }
+#endif
+
+  if (pid == -1)
+    pid = 0;
+
+  if (!pid)
+    handle = GetCurrentProcess();
+  else
+    handle =
+        OpenProcess(PROCESS_TERMINATE | PROCESS_QUERY_INFORMATION, FALSE, pid);
+  if (!handle)
+    goto something_went_wrong;
+
+  switch (sig) {
+  case SIGKILL:
+  case SIGTERM:
+  case SIGINT: /* terminate */
+    if (!TerminateProcess(handle, 1))
+      goto something_went_wrong;
+    break;
+  case 0: /* check status */
+    if (!GetExitCodeProcess(handle, &status))
+      goto something_went_wrong;
+    if (status != STILL_ACTIVE) {
+      errno = ESRCH;
+      goto cleanup_after_error;
+    }
+    break;
+  default: /* not supported? */
+    errno = ENOSYS;
+    goto cleanup_after_error;
+  }
+
+  if (pid) {
+    CloseHandle(handle);
+  }
+  return 0;
+
+something_went_wrong:
+  switch (GetLastError()) {
+  case ERROR_INVALID_PARAMETER:
+    errno = ESRCH;
+    break;
+  case ERROR_ACCESS_DENIED:
+    errno = EPERM;
+    if (handle && GetExitCodeProcess(handle, &status) && status != STILL_ACTIVE)
+      errno = ESRCH;
+    break;
+  default:
+    errno = GetLastError();
+  }
+cleanup_after_error:
+  if (handle && pid)
+    CloseHandle(handle);
+  return -1;
+}
+
+ssize_t pread(int fd, void *buf, size_t count, off_t offset) {
+  /* Credit to Jan Biedermann (GitHub: @janbiedermann) */
+  ssize_t bytes_read = 0;
+  HANDLE handle = (HANDLE)_get_osfhandle(fd);
+  if (handle == INVALID_HANDLE_VALUE)
+    goto bad_file;
+  OVERLAPPED overlapped = {0};
+  if (offset > 0)
+    overlapped.Offset = offset;
+  if (ReadFile(handle, buf, count, (u_long *)&bytes_read, &overlapped))
+    return bytes_read;
+  if (GetLastError() == ERROR_HANDLE_EOF)
+    return bytes_read;
+  errno = EIO;
+  return -1;
+bad_file:
+  errno = EBADF;
+  return -1;
+}
+
+ssize_t pwrite(int fd, const void *buf, size_t count, off_t offset) {
+  /* Credit to Jan Biedermann (GitHub: @janbiedermann) */
+  ssize_t bytes_written = 0;
+  HANDLE handle = (HANDLE)_get_osfhandle(fd);
+  if (handle == INVALID_HANDLE_VALUE)
+    goto bad_file;
+  OVERLAPPED overlapped = {0};
+  if (offset > 0)
+    overlapped.Offset = offset;
+  if (WriteFile(handle, buf, count, (u_long *)&bytes_written, &overlapped))
+    return bytes_written;
+  errno = EIO;
+  return -1;
+bad_file:
+  errno = EBADF;
+  return -1;
+}
+
+pid_t wait(int *stat_loc) {
+  fprintf(stderr, "wait() is not supported on Windows.\n");
+  errno = ENOSYS;
+  return -1;
+}
+
+pid_t waitpid(pid_t pid, int *stat_loc, int options) {
+  fprintf(stderr, "waitpid() is not supported on Windows.\n");
+  errno = ENOSYS;
+  return -1;
+}
 #endif
 
 /* *****************************************************************************
@@ -185,7 +356,7 @@ typedef struct {
   uint8_t close;
   /** peer address length */
   uint8_t addr_len;
-  /** peer address length */
+  /** peer address */
   uint8_t addr[48];
   /** RW hooks. */
   fio_rw_hook_s *rw_hooks;
@@ -193,6 +364,10 @@ typedef struct {
   void *rw_udata;
   /* Objects linked to the UUID */
   fio_uuid_links_s links;
+#ifdef __MINGW32__
+  /* Winsock operating system socket handle */
+  SOCKET socket_handle;
+#endif
 } fio_fd_data_s;
 
 typedef struct {
@@ -219,7 +394,7 @@ typedef struct {
   uint32_t max_protocol_fd;
   /* timer handler */
   pid_t parent;
-#if FIO_ENGINE_POLL
+#if FIO_ENGINE_POLL || FIO_ENGINE_WSAPOLL
   struct pollfd *poll;
 #endif
   fio_fd_data_s info[];
@@ -296,6 +471,9 @@ static inline int fio_clear_fd(intptr_t fd, uint8_t is_open) {
   protocol = fd_data(fd).protocol;
   rw_hooks = fd_data(fd).rw_hooks;
   rw_udata = fd_data(fd).rw_udata;
+#ifdef __MINGW32__
+  SOCKET socket_handle = fd_data(fd).socket_handle;
+#endif
   fd_data(fd) = (fio_fd_data_s){
       .open = is_open,
       .sock_lock = fd_data(fd).sock_lock,
@@ -303,8 +481,11 @@ static inline int fio_clear_fd(intptr_t fd, uint8_t is_open) {
       .rw_hooks = (fio_rw_hook_s *)&FIO_DEFAULT_RW_HOOKS,
       .counter = fd_data(fd).counter + 1,
       .packet_last = &fd_data(fd).packet,
+#ifdef __MINGW32__
+      .socket_handle = socket_handle,
+#endif
   };
-  if (fio_data->max_protocol_fd < fd) {
+  if (is_open && fio_data->max_protocol_fd < fd) {
     fio_data->max_protocol_fd = fd;
   } else {
     while (fio_data->max_protocol_fd &&
@@ -652,21 +833,40 @@ Suspending and renewing thread execution (signaling events)
  * progressive nano-sleep throttling system that is less exact.
  */
 #ifndef FIO_DEFER_THROTTLE_POLL
+#ifdef __MINGW32__
+#define FIO_DEFER_THROTTLE_POLL 1
+#else
 #define FIO_DEFER_THROTTLE_POLL 0
 #endif
-
+#endif
+  
 typedef struct fio_thread_queue_s {
   fio_ls_embd_s node;
-  int fd_wait;   /* used for weaiting (read signal) */
+#ifdef __MINGW32__
+  HANDLE handle;
+  int in_list;
+#else
+  int fd_wait;   /* used for waiting (read signal) */
   int fd_signal; /* used for signalling (write) */
+#endif
 } fio_thread_queue_s;
 
 fio_ls_embd_s fio_thread_queue = FIO_LS_INIT(fio_thread_queue);
 fio_lock_i fio_thread_lock = FIO_LOCK_INIT;
+
+#ifdef __MINGW32__
+static __thread fio_thread_queue_s fio_thread_data = {.handle = INVALID_HANDLE_VALUE };
+#else
 static __thread fio_thread_queue_s fio_thread_data = {.fd_wait = -1,
                                                       .fd_signal = -1};
+#endif
 
 FIO_FUNC inline void fio_thread_make_suspendable(void) {
+#ifdef __MINGW32__
+  /** create automatically reseting event */
+  fio_thread_data.handle = CreateEvent(NULL, FALSE, FALSE, TEXT("thread signal"));
+  fio_thread_data.in_list = 0;
+#else
   if (fio_thread_data.fd_signal >= 0)
     return;
   int fd[2] = {0, 0};
@@ -678,19 +878,38 @@ FIO_FUNC inline void fio_thread_make_suspendable(void) {
              "(fio) couldn't set internal pipe to non-blocking mode.");
   fio_thread_data.fd_wait = fd[0];
   fio_thread_data.fd_signal = fd[1];
+#endif
 }
 
 FIO_FUNC inline void fio_thread_cleanup(void) {
+#ifdef __MINGW32__
+  HANDLE h = fio_thread_data.handle;
+  fio_thread_data.handle = INVALID_HANDLE_VALUE;
+  CloseHandle(h);
+#else
   if (fio_thread_data.fd_signal < 0)
     return;
   close(fio_thread_data.fd_wait);
   close(fio_thread_data.fd_signal);
   fio_thread_data.fd_wait = -1;
   fio_thread_data.fd_signal = -1;
+#endif
 }
 
 /* suspend thread execution (might be resumed unexpectedly) */
 FIO_FUNC void fio_thread_suspend(void) {
+#ifdef __MINGW32__
+  fio_lock(&fio_thread_lock);
+  /** don't add thread to queue if its already in there
+   * to prevent queue breakage
+   * can happen if WaitForSingleObject returns for other reasons */
+  if (!fio_thread_data.in_list) {
+    fio_ls_embd_push(&fio_thread_queue, &fio_thread_data.node);
+    fio_thread_data.in_list = 1;
+  }
+  fio_unlock(&fio_thread_lock);
+  WaitForSingleObject(fio_thread_data.handle, INFINITE);
+#else
   fio_lock(&fio_thread_lock);
   fio_ls_embd_push(&fio_thread_queue, &fio_thread_data.node);
   fio_unlock(&fio_thread_lock);
@@ -709,10 +928,22 @@ FIO_FUNC void fio_thread_suspend(void) {
     fio_ls_embd_remove(&fio_thread_data.node);
     fio_unlock(&fio_thread_lock);
   }
+#endif
 }
 
 /* wake up a single thread */
 FIO_FUNC void fio_thread_signal(void) {
+#ifdef __MINGW32__
+  fio_lock(&fio_thread_lock);
+  fio_thread_queue_s *t = (fio_thread_queue_s *)fio_ls_embd_shift(&fio_thread_queue);
+  if (t) {
+    t->in_list = 0;
+    fio_unlock(&fio_thread_lock);
+    SetEvent(t->handle);
+  } else {
+    fio_unlock(&fio_thread_lock);
+  }
+#else
   fio_thread_queue_s *t;
   int fd = -2;
   fio_lock(&fio_thread_lock);
@@ -728,6 +959,7 @@ FIO_FUNC void fio_thread_signal(void) {
     /* hardly the best way, but there's a thread sleeping on air */
     kill(getpid(), SIGCONT);
   }
+#endif
 }
 
 /* wake up all threads */
@@ -739,7 +971,7 @@ FIO_FUNC void fio_thread_broadcast(void) {
 
 static size_t fio_poll(void);
 /**
- * A thread entering this function should wait for new evennts.
+ * A thread entering this function should wait for new events.
  */
 static void fio_defer_thread_wait(void) {
 #if FIO_ENGINE_POLL
@@ -1341,7 +1573,11 @@ Section Start Marker
 
 volatile uint8_t fio_signal_children_flag = 0;
 volatile fio_lock_i fio_signal_set_flag = 0;
-/* store old signal handlers to propegate signal handling */
+/* store old signal handlers to propagate signal handling */
+#ifdef __MINGW32__
+void (*fio_old_sig_int)(int);
+void (*fio_old_sig_term)(int);
+#else
 static struct sigaction fio_old_sig_chld;
 static struct sigaction fio_old_sig_pipe;
 static struct sigaction fio_old_sig_term;
@@ -1349,6 +1585,10 @@ static struct sigaction fio_old_sig_int;
 #if !FIO_DISABLE_HOT_RESTART
 static struct sigaction fio_old_sig_usr1;
 #endif
+#endif
+
+#ifndef __MINGW32__
+/* there are no process children on Windows, as there is only one worker */
 
 /*
  * Zombie Reaping
@@ -1380,10 +1620,15 @@ void fio_reap_children(void) {
     exit(errno);
   }
 }
+#endif
 
 /* handles the SIGUSR1, SIGINT and SIGTERM signals. */
 static void sig_int_handler(int sig) {
+#ifdef __MINGW32__
+  void (*old)(int) = NULL;
+#else
   struct sigaction *old = NULL;
+#endif
   switch (sig) {
 #if !FIO_DISABLE_HOT_RESTART
   case SIGUSR1:
@@ -1394,28 +1639,44 @@ static void sig_int_handler(int sig) {
     /* fallthrough */
   case SIGINT:
     if (!old)
+#ifdef __MINGW32__
+      old = fio_old_sig_int;
+#else
       old = &fio_old_sig_int;
+#endif
     /* fallthrough */
   case SIGTERM:
     if (!old)
+#ifdef __MINGW32__
+      old = fio_old_sig_term;
+#else
       old = &fio_old_sig_term;
+#endif
     fio_stop();
     break;
+#ifndef __MINGW32__
   case SIGPIPE:
     if (!old)
       old = &fio_old_sig_pipe;
+#endif
   /* fallthrough */
   default:
     break;
   }
+#ifndef __MINGW32__
   /* propagate signale handling to previous existing handler (if any) */
   if (old && old->sa_handler != SIG_IGN && old->sa_handler != SIG_DFL)
     old->sa_handler(sig);
+#endif
 }
 
 /* setup handling for the SIGUSR1, SIGPIPE, SIGINT and SIGTERM signals. */
 static void fio_signal_handler_setup(void) {
   /* setup signal handling */
+#ifdef __MINGW32__
+  fio_old_sig_int = signal(SIGINT, sig_int_handler);
+  fio_old_sig_term = signal(SIGTERM, sig_int_handler);
+#else
   struct sigaction act;
   if (fio_trylock(&fio_signal_set_flag))
     return;
@@ -1447,9 +1708,14 @@ static void fio_signal_handler_setup(void) {
     perror("couldn't set signal handler");
     return;
   };
+#endif
 }
 
 void fio_signal_handler_reset(void) {
+#ifdef __MINGW32__
+  signal(SIGINT, fio_old_sig_int);
+  signal(SIGTERM, fio_old_sig_term);
+#else
   struct sigaction old;
   if (fio_signal_set_flag)
     return;
@@ -1457,6 +1723,7 @@ void fio_signal_handler_reset(void) {
   memset(&old, 0, sizeof(old));
   sigaction(SIGINT, &fio_old_sig_int, &old);
   sigaction(SIGTERM, &fio_old_sig_term, &old);
+
   sigaction(SIGPIPE, &fio_old_sig_pipe, &old);
   if (fio_old_sig_chld.sa_handler)
     sigaction(SIGCHLD, &fio_old_sig_chld, &old);
@@ -1464,10 +1731,13 @@ void fio_signal_handler_reset(void) {
   sigaction(SIGUSR1, &fio_old_sig_usr1, &old);
   memset(&fio_old_sig_usr1, 0, sizeof(fio_old_sig_usr1));
 #endif
+#endif
   memset(&fio_old_sig_int, 0, sizeof(fio_old_sig_int));
   memset(&fio_old_sig_term, 0, sizeof(fio_old_sig_term));
+#ifndef __MINGW32__
   memset(&fio_old_sig_pipe, 0, sizeof(fio_old_sig_pipe));
   memset(&fio_old_sig_chld, 0, sizeof(fio_old_sig_chld));
+#endif
 }
 
 /**
@@ -1495,7 +1765,11 @@ pid_t fio_parent_pid(void) { return fio_data->parent; }
 
 static inline size_t fio_detect_cpu_cores(void) {
   ssize_t cpu_count = 0;
-#ifdef _SC_NPROCESSORS_ONLN
+#if defined(__MINGW32__)
+  SYSTEM_INFO sys_info;
+  GetSystemInfo(&sys_info);
+  cpu_count = sys_info.dwNumberOfProcessors;
+#elif defined(_SC_NPROCESSORS_ONLN)
   cpu_count = sysconf(_SC_NPROCESSORS_ONLN);
   if (cpu_count < 0) {
     FIO_LOG_WARNING("CPU core count auto-detection failed.");
@@ -1536,11 +1810,16 @@ void fio_expected_concurrency(int16_t *threads, int16_t *processes) {
       cpu_count = FIO_CPU_CORES_LIMIT;
     }
 #endif
+#ifdef __MINGW32__
+    *threads = (int16_t)cpu_count;
+    *processes = 1;
+#else
     *threads = *processes = (int16_t)cpu_count;
     if (cpu_count > 3) {
       /* leave a core available for the kernel */
       --(*processes);
     }
+#endif
   } else if (*threads < 0 || *processes < 0) {
     /* Set any option that is less than 0 be equal to cores/value */
     /* Set any option equal to 0 be equal to the other option in value */
@@ -1577,9 +1856,14 @@ void fio_expected_concurrency(int16_t *threads, int16_t *processes) {
     }
   }
 
-  /* make sure we have at least one process and at least one thread */
+  /* make sure we have at least one (or exactly one on Windows) process and at least one thread */
+#ifdef __MINGW32__
+  FIO_LOG_WARNING("Using only 1 worker on Windows, because fork() support is missing.");
+  *processes = 1;
+#else
   if (*processes <= 0)
     *processes = 1;
+#endif
   if (*threads <= 0)
     *threads = 1;
 }
@@ -2048,6 +2332,188 @@ Section Start Marker
 
 
 
+
+                       Polling State Machine - wsapoll
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+***************************************************************************** */
+
+#if FIO_ENGINE_WSAPOLL
+
+void fio_clear_handle(int fd);
+int fio_fd4handle(SOCKET handle);
+
+/**
+ * Returns a C string detailing the IO engine selected during compilation.
+ *
+ * Valid values are "kqueue", "epoll", "poll" and "wsapoll".
+ */
+char const *fio_engine(void) { return "wsapoll"; }
+
+#define FIO_POLL_READ_EVENTS (POLLIN)
+#define FIO_POLL_WRITE_EVENTS (POLLOUT)
+
+static void fio_poll_close(void) {
+  WSACleanup();
+}
+
+static void fio_poll_init(void) {
+  int result;
+  WSADATA wsa_data;
+  result = WSAStartup(MAKEWORD(2,2), &wsa_data);
+  if (result != 0) {
+    FIO_LOG_FATAL("WSA startup failed.\n");
+    exit(result);
+  }
+}
+
+static inline void fio_poll_remove_fd(int fd) {
+  fio_data->poll[fd].fd = -1;
+  fio_data->poll[fd].events = 0;
+}
+
+static inline void fio_poll_add_read(int fd) {
+  fio_data->poll[fd].fd = fd;
+  fio_data->poll[fd].events |= FIO_POLL_READ_EVENTS;
+}
+
+static inline void fio_poll_add_write(int fd) {
+  fio_data->poll[fd].fd = fd;
+  fio_data->poll[fd].events |= FIO_POLL_WRITE_EVENTS;
+}
+
+static inline void fio_poll_add(int fd) {
+  fio_data->poll[fd].fd = fd;
+  fio_data->poll[fd].events = FIO_POLL_READ_EVENTS | FIO_POLL_WRITE_EVENTS;
+}
+
+static inline void fio_poll_remove_read(int fd) {
+  fio_lock(&fio_data->lock);
+  if (fio_data->poll[fd].events & FIO_POLL_WRITE_EVENTS)
+    fio_data->poll[fd].events = FIO_POLL_WRITE_EVENTS;
+  else {
+    fio_poll_remove_fd(fd);
+  }
+  fio_unlock(&fio_data->lock);
+}
+
+static inline void fio_poll_remove_write(int fd) {
+  fio_lock(&fio_data->lock);
+  if (fio_data->poll[fd].events & FIO_POLL_READ_EVENTS)
+    fio_data->poll[fd].events = FIO_POLL_READ_EVENTS;
+  else {
+    fio_poll_remove_fd(fd);
+  }
+  fio_unlock(&fio_data->lock);
+}
+
+/** returns non-zero if events were scheduled, 0 if idle */
+static size_t fio_poll(void) {
+  /* shrink fd poll range */
+  size_t end = fio_data->capa; // max_protocol_fd might break TLS
+  size_t start = 0;
+  struct pollfd *list = NULL;
+  fio_lock(&fio_data->lock);
+  while (start < end && fio_data->poll[start].fd == (SOCKET)-1)
+    ++start;
+  while (start < end && fio_data->poll[end-1].fd == (SOCKET)-1)
+    --end;
+  fio_unlock(&fio_data->lock);
+
+    /* copy poll list for multi-threaded poll */
+  list = fio_malloc(sizeof(*list) * (end - start + 1));
+  FIO_ASSERT_ALLOC(list);
+
+  // replace facil fds with actual Windows socket handles in list
+  size_t i = 0;
+  size_t j = 0;
+
+  for(i = start; i <= end; i++) {
+    if (fd_data(i).socket_handle != INVALID_SOCKET) {
+      list[j].fd = fd_data(i).socket_handle;
+      list[j].events = fio_data->poll[i].events;
+      list[j].revents = fio_data->poll[i].revents;
+      j++;
+    }
+  }
+
+  if (WSAPoll(list, j, 1) == SOCKET_ERROR) {
+    int error = WSAGetLastError();
+    FIO_LOG_DEBUG("fio_poll WSAPoll error %i", error);
+    goto finish;
+  }
+
+  size_t count = 0;
+  int fd;
+
+  for (i = 0; i < j; i++) {
+    if (list[i].fd != INVALID_SOCKET && list[i].revents) {
+      fd = fio_fd4handle(list[i].fd);
+      if (fd == -1)
+        continue;
+      touchfd(fd);
+      ++count;
+
+      if (list[i].revents & FIO_POLL_WRITE_EVENTS) {
+        // FIO_LOG_DEBUG("Poll Write %zu => %p", fd, (void *)fd2uuid(fd));
+        fio_poll_remove_write(fd);
+        fio_defer_push_urgent(deferred_on_ready, (void *)fd2uuid(fd), NULL);
+      }
+      if (list[i].revents & FIO_POLL_READ_EVENTS) {
+        // FIO_LOG_DEBUG("Poll Read %zu => %p", fd, (void *)fd2uuid(fd));
+        fio_poll_remove_read(fd);
+        fio_defer_push_task(deferred_on_data, (void *)fd2uuid(fd), NULL);
+        continue;
+      }
+      if (list[i].revents & (POLLHUP | POLLERR)) {
+        // FIO_LOG_DEBUG("Poll Hangup %zu => %p", fd, (void *)fd2uuid(fd));
+        fio_poll_remove_fd(fd);
+        fio_force_close_in_poll(fd2uuid(fd));
+        continue;
+      }
+      if (list[i].revents & POLLNVAL) {
+        // FIO_LOG_DEBUG("Poll Invalid %zu => %p", fd, (void *)fd2uuid(fd));
+        fio_poll_remove_fd(fd);
+        fio_lock(&fd_data(fd).protocol_lock);
+        fio_clear_handle(fd);
+        fio_clear_fd(fd, 0);
+        fio_unlock(&fd_data(fd).protocol_lock);
+      }
+    }
+  }
+finish:
+  fio_free(list);
+  return count;
+}
+
+#endif /* FIO_ENGINE_WSAPOLL */
+
+/* *****************************************************************************
+Section Start Marker
+
+
+
+
+
+
+
+
+
+
+
+
                          IO Callbacks / Event Handling
 
 
@@ -2348,6 +2814,53 @@ static void fio_tcp_addr_cpy(int fd, int family, struct sockaddr *addrinfo) {
   }
 }
 
+#ifdef __MINGW32__
+int fio_handle2fd(SOCKET handle) {
+  int found = 0;
+  int fd = -1;
+  int it = 0;
+  while(!found) {
+    fd++;
+    if (fd >= (int)fio_data->capa) {
+      fd = 0;
+      it++;
+      if (it > 2)
+        return -1;
+      fio_reschedule_thread();
+    }
+    if (fd_data(fd).socket_handle != INVALID_SOCKET && fd_data(fd).socket_handle > 0)
+      continue;
+    fio_lock(&(fd_data(fd).sock_lock));
+    if (fd_data(fd).socket_handle != INVALID_SOCKET && fd_data(fd).socket_handle > 0) {
+      fio_unlock(&(fd_data(fd).sock_lock));
+      continue;
+    } else {
+      fd_data(fd).socket_handle = handle;
+      found = 1;
+      fio_unlock(&(fd_data(fd).sock_lock));
+    }
+  }
+  return fd;
+}
+
+int fio_fd4handle(SOCKET handle) {
+  unsigned int fd = 0;
+  while(fd < fio_data->capa) {
+    if (fd_data(fd).socket_handle == handle) {
+      return fd;
+    }
+    fd++;
+  }
+  return -1;
+}
+
+void fio_clear_handle(int fd) {
+  fio_lock(&(fd_data(fd).sock_lock));
+  fd_data(fd).socket_handle = INVALID_SOCKET;
+  fio_unlock(&(fd_data(fd).sock_lock));
+}
+#endif
+
 /**
  * `fio_accept` accepts a new socket connection from a server socket - see the
  * server flag on `fio_socket`.
@@ -2358,30 +2871,57 @@ static void fio_tcp_addr_cpy(int fd, int family, struct sockaddr *addrinfo) {
 intptr_t fio_accept(intptr_t srv_uuid) {
   struct sockaddr_in6 addrinfo[2]; /* grab a slice of stack (aligned) */
   socklen_t addrlen = sizeof(addrinfo);
+#ifdef __MINGW32__
+  SOCKET client;
+#else
   int client;
+#endif
 #ifdef SOCK_NONBLOCK
   client = accept4(fio_uuid2fd(srv_uuid), (struct sockaddr *)addrinfo, &addrlen,
                    SOCK_NONBLOCK | SOCK_CLOEXEC);
   if (client <= 0)
     return -1;
 #else
+#ifdef __MINGW32__
+  client = accept(fd_data(fio_uuid2fd(srv_uuid)).socket_handle, (struct sockaddr *)addrinfo, &addrlen);
+  if (client == INVALID_SOCKET)
+    return -1;
+#else
   client = accept(fio_uuid2fd(srv_uuid), (struct sockaddr *)addrinfo, &addrlen);
   if (client <= 0)
     return -1;
+#endif
   if (fio_set_non_block(client) == -1) {
-    close(client);
+#ifdef __MINGW32__
+      closesocket(client);
+#else      
+      close(client);
+#endif
     return -1;
   }
 #endif
   // avoid the TCP delay algorithm.
   {
+  #ifdef __MINGW32__
+    char optval = 1;
+  #else
     int optval = 1;
+  #endif
     setsockopt(client, IPPROTO_TCP, TCP_NODELAY, &optval, sizeof(optval));
   }
   // handle socket buffers.
   {
     int optval = 0;
     socklen_t size = (socklen_t)sizeof(optval);
+#ifdef __MINGW32__
+    if (!getsockopt(client, SOL_SOCKET, SO_SNDBUF, (char *)&optval, &size) &&
+        optval <= 131072) {
+      optval = 131072;
+      setsockopt(client, SOL_SOCKET, SO_SNDBUF, (char *)&optval, sizeof(optval));
+      optval = 131072;
+      setsockopt(client, SOL_SOCKET, SO_RCVBUF, (char *)&optval, sizeof(optval));
+    }
+#else
     if (!getsockopt(client, SOL_SOCKET, SO_SNDBUF, &optval, &size) &&
         optval <= 131072) {
       optval = 131072;
@@ -2389,8 +2929,13 @@ intptr_t fio_accept(intptr_t srv_uuid) {
       optval = 131072;
       setsockopt(client, SOL_SOCKET, SO_RCVBUF, &optval, sizeof(optval));
     }
+#endif
   }
-
+#ifdef __MINGW32__
+  client = fio_handle2fd(client);
+  if (client == (SOCKET)-1)
+    return -1;
+#endif
   fio_lock(&fd_data(client).protocol_lock);
   fio_clear_fd(client, 1);
   fio_unlock(&fd_data(client).protocol_lock);
@@ -2409,6 +2954,151 @@ intptr_t fio_accept(intptr_t srv_uuid) {
   return fd2uuid(client);
 }
 
+/* Creates a TCP/IP socket - returning it's uuid (or -1) */
+static intptr_t fio_tcp_socket(const char *address, const char *port,
+                               uint8_t server) {
+  /* TCP/IP socket */
+  // setup the address
+  struct addrinfo hints = {0};
+  struct addrinfo *addrinfo;       // will point to the results
+  memset(&hints, 0, sizeof hints); // make sure the struct is empty
+  hints.ai_family = AF_UNSPEC;     // don't care IPv4 or IPv6
+  hints.ai_socktype = SOCK_STREAM; // TCP stream sockets
+  hints.ai_flags = AI_PASSIVE;     // fill in my IP for me
+  if (getaddrinfo(address, port, &hints, &addrinfo)) {
+    // perror("addr err");
+    return -1;
+  }
+  // get the file descriptor
+#ifdef __MINGW32__
+  SOCKET fd =
+      socket(addrinfo->ai_family, addrinfo->ai_socktype, addrinfo->ai_protocol);
+  if (fd == INVALID_SOCKET) {
+    freeaddrinfo(addrinfo);
+    return -1;
+  }
+#else
+  int fd =
+      socket(addrinfo->ai_family, addrinfo->ai_socktype, addrinfo->ai_protocol);
+  if (fd <= 0) {
+    freeaddrinfo(addrinfo);
+    return -1;
+  }
+#endif
+  // make sure the socket is non-blocking
+  if (fio_set_non_block(fd) < 0) {
+    freeaddrinfo(addrinfo);
+#ifdef __MINGW32__
+      closesocket(fd);
+#else      
+      close(fd); // socket
+#endif
+    return -1;
+  }
+  if (server) {
+    {
+      // avoid the "address taken"
+  #ifdef __MINGW32__
+    char optval = 1;
+  #else
+    int optval = 1;
+  #endif
+      setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval));
+    }
+    // bind the address to the socket
+    int bound = 0;
+    for (struct addrinfo *i = addrinfo; i != NULL; i = i->ai_next) {
+      if (!bind(fd, i->ai_addr, i->ai_addrlen))
+        bound = 1;
+    }
+    if (!bound) {
+      // perror("bind err");
+      freeaddrinfo(addrinfo);
+#ifdef __MINGW32__
+      closesocket(fd);
+#else      
+      close(fd); // socket
+#endif
+      return -1;
+    }
+#ifdef TCP_FASTOPEN
+    {
+      // support TCP Fast Open when available
+      int optval = 128;
+      setsockopt(fd, addrinfo->ai_protocol, TCP_FASTOPEN, &optval,
+                 sizeof(optval));
+    }
+#endif
+    if (listen(fd, SOMAXCONN) < 0) {
+      freeaddrinfo(addrinfo);
+#ifdef __MINGW32__
+      closesocket(fd);
+#else      
+      close(fd); // socket
+#endif
+      return -1;
+    }
+  } else {
+#ifdef __MINGW32__
+    char optval = 1;
+#else
+    int optval = 1;
+#endif
+    setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &optval, sizeof(optval));
+    errno = 0;
+    for (struct addrinfo *i = addrinfo; i; i = i->ai_next) {
+#ifdef __MINGW32__
+      int connres = connect(fd, i->ai_addr, i->ai_addrlen);
+      if (connres == SOCKET_ERROR) {
+        int error = WSAGetLastError();
+        if (error == WSAEISCONN || error == WSAEWOULDBLOCK || error == WSAEINPROGRESS) 
+          goto socket_okay;
+      } else if (connres == 0) { goto socket_okay; }
+#else
+      if (connect(fd, i->ai_addr, i->ai_addrlen) == 0 || errno == EINPROGRESS)
+        goto socket_okay;
+#endif
+    }
+    freeaddrinfo(addrinfo);
+#ifdef __MINGW32__
+    closesocket(fd);
+#else      
+    close(fd); // socket
+#endif
+    return -1;
+  }
+socket_okay:
+#ifdef __MINGW32__
+  fd = fio_handle2fd(fd);
+  if (fd == (SOCKET)-1)
+    return -1;
+#endif
+  fio_lock(&fd_data(fd).protocol_lock);
+  fio_clear_fd(fd, 1);
+  fio_unlock(&fd_data(fd).protocol_lock);
+  fio_tcp_addr_cpy(fd, addrinfo->ai_family, (void *)addrinfo);
+  freeaddrinfo(addrinfo);
+  intptr_t ufd = fd2uuid(fd);
+  return ufd;
+}
+
+#ifdef __MINGW32__
+/* Creates a tcp socket in the 10000 to 19999 port range */
+static intptr_t fio_unix_socket(const char *address, uint8_t server) {
+  static char *localhost = "localhost";
+  char localport[6];
+  int vary = _getpid();
+  int iterations = sizeof(int) * 8;
+  int i = iterations;
+  while (vary > 9999) {
+    i--;
+    vary &= ~(1u << i);
+  }
+  sprintf_s(localport, 6, "1%04u", vary);
+  FIO_LOG_WARNING("Using tcp socket on localhost port %s for IPC instead of unix socket on Windows.", localport);
+  return fio_tcp_socket(localhost, localport, server);
+}
+#else
 /* Creates a Unix socket - returning it's uuid (or -1) */
 static intptr_t fio_unix_socket(const char *address, uint8_t server) {
   /* Unix socket */
@@ -2430,27 +3120,27 @@ static intptr_t fio_unix_socket(const char *address, uint8_t server) {
   if (fd == -1) {
     return -1;
   }
-  if (fio_set_non_block(fd) == -1) {
-    close(fd);
+  if (fio_set_non_block(fd) == -1) {   
+      close(fd);
     return -1;
   }
   if (server) {
     unlink(addr.sun_path);
     if (bind(fd, (struct sockaddr *)&addr, sizeof(addr)) == -1) {
-      // perror("couldn't bind unix socket");
+      // perror("couldn't bind unix socket");   
       close(fd);
       return -1;
     }
     if (listen(fd, SOMAXCONN) < 0) {
-      // perror("couldn't start listening to unix socket");
+      // perror("couldn't start listening to unix socket");     
       close(fd);
       return -1;
     }
-    /* chmod for foriegn connections */
+    /* chmod for foreign connections */
     fchmod(fd, 0777);
   } else {
     if (connect(fd, (struct sockaddr *)&addr, sizeof(addr)) == -1 &&
-        errno != EINPROGRESS) {
+        errno != EINPROGRESS) {    
       close(fd);
       return -1;
     }
@@ -2464,86 +3154,7 @@ static intptr_t fio_unix_socket(const char *address, uint8_t server) {
   }
   return fd2uuid(fd);
 }
-
-/* Creates a TCP/IP socket - returning it's uuid (or -1) */
-static intptr_t fio_tcp_socket(const char *address, const char *port,
-                               uint8_t server) {
-  /* TCP/IP socket */
-  // setup the address
-  struct addrinfo hints = {0};
-  struct addrinfo *addrinfo;       // will point to the results
-  memset(&hints, 0, sizeof hints); // make sure the struct is empty
-  hints.ai_family = AF_UNSPEC;     // don't care IPv4 or IPv6
-  hints.ai_socktype = SOCK_STREAM; // TCP stream sockets
-  hints.ai_flags = AI_PASSIVE;     // fill in my IP for me
-  if (getaddrinfo(address, port, &hints, &addrinfo)) {
-    // perror("addr err");
-    return -1;
-  }
-  // get the file descriptor
-  int fd =
-      socket(addrinfo->ai_family, addrinfo->ai_socktype, addrinfo->ai_protocol);
-  if (fd <= 0) {
-    freeaddrinfo(addrinfo);
-    return -1;
-  }
-  // make sure the socket is non-blocking
-  if (fio_set_non_block(fd) < 0) {
-    freeaddrinfo(addrinfo);
-    close(fd);
-    return -1;
-  }
-  if (server) {
-    {
-      // avoid the "address taken"
-      int optval = 1;
-      setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval));
-    }
-    // bind the address to the socket
-    int bound = 0;
-    for (struct addrinfo *i = addrinfo; i != NULL; i = i->ai_next) {
-      if (!bind(fd, i->ai_addr, i->ai_addrlen))
-        bound = 1;
-    }
-    if (!bound) {
-      // perror("bind err");
-      freeaddrinfo(addrinfo);
-      close(fd);
-      return -1;
-    }
-#ifdef TCP_FASTOPEN
-    {
-      // support TCP Fast Open when available
-      int optval = 128;
-      setsockopt(fd, addrinfo->ai_protocol, TCP_FASTOPEN, &optval,
-                 sizeof(optval));
-    }
 #endif
-    if (listen(fd, SOMAXCONN) < 0) {
-      freeaddrinfo(addrinfo);
-      close(fd);
-      return -1;
-    }
-  } else {
-    int one = 1;
-    setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
-    errno = 0;
-    for (struct addrinfo *i = addrinfo; i; i = i->ai_next) {
-      if (connect(fd, i->ai_addr, i->ai_addrlen) == 0 || errno == EINPROGRESS)
-        goto socket_okay;
-    }
-    freeaddrinfo(addrinfo);
-    close(fd);
-    return -1;
-  }
-socket_okay:
-  fio_lock(&fd_data(fd).protocol_lock);
-  fio_clear_fd(fd, 1);
-  fio_unlock(&fd_data(fd).protocol_lock);
-  fio_tcp_addr_cpy(fd, addrinfo->ai_family, (void *)addrinfo);
-  freeaddrinfo(addrinfo);
-  return fd2uuid(fd);
-}
 
 /* PUBLIC API: opens a server or client socket */
 intptr_t fio_socket(const char *address, const char *port, uint8_t server) {
@@ -2606,7 +3217,15 @@ Internal socket flushing related functions
 
 #endif
 
+#ifdef __MINGW32__
+static void fio_sock_perform_close_fd(intptr_t fd) { 
+  SOCKET s = fd_data(fd).socket_handle;
+  fio_clear_handle(fd);
+  closesocket(s);
+}
+#else
 static void fio_sock_perform_close_fd(intptr_t fd) { close(fd); }
+#endif
 
 static inline void fio_sock_packet_rotate_unsafe(uintptr_t fd) {
   fio_packet_s *packet = fd_data(fd).packet;
@@ -2844,8 +3463,7 @@ ssize_t fio_write2_fn(intptr_t uuid, fio_write_args_s options) {
 locked_error:
   fio_unlock(&uuid_data(uuid).sock_lock);
   fio_packet_free(packet);
-  errno = EBADF;
-  return -1;
+  /** fallthrough and free buffer */
 error:
   if (options.after.dealloc) {
     options.after.dealloc((void *)options.data.buffer);
@@ -2924,8 +3542,12 @@ void fio_force_close(intptr_t uuid) {
   fio_lock(&uuid_data(uuid).protocol_lock);
   fio_clear_fd(fio_uuid2fd(uuid), 0);
   fio_unlock(&uuid_data(uuid).protocol_lock);
+#ifdef __MINGW32__
+  fio_sock_perform_close_fd(fio_uuid2fd(uuid));
+#else
   close(fio_uuid2fd(uuid));
-#if FIO_ENGINE_POLL
+#endif
+#if FIO_ENGINE_POLL || FIO_ENGINE_WSAPOLL
   fio_poll_remove_fd(fio_uuid2fd(uuid));
 #endif
   if (fio_data->connection_count)
@@ -3062,12 +3684,37 @@ Connection Read / Write Hooks, for overriding the system calls
 
 static ssize_t fio_hooks_default_read(intptr_t uuid, void *udata, void *buf,
                                       size_t count) {
+#ifdef __MINGW32__
+  int len = recv(fd_data(fio_uuid2fd(uuid)).socket_handle, buf, count, 0);
+  if (len != SOCKET_ERROR)
+    return len;
+  int error = WSAGetLastError();
+  switch (error) {
+    case WSAEWOULDBLOCK:
+      errno = EWOULDBLOCK;
+      break;
+    case WSAENOTCONN:
+      errno = ENOTCONN;
+      break;
+    case WSAEINTR:
+      errno = EINTR;
+      break;
+    default:
+      errno = error;
+  }
+  return -1;
+#else
   return read(fio_uuid2fd(uuid), buf, count);
+#endif
   (void)(udata);
 }
 static ssize_t fio_hooks_default_write(intptr_t uuid, void *udata,
                                        const void *buf, size_t count) {
+#ifdef __MINGW32__
+  return send(fd_data(fio_uuid2fd(uuid)).socket_handle, buf, count, 0);
+#else
   return write(fio_uuid2fd(uuid), buf, count);
+#endif
   (void)(udata);
 }
 
@@ -3548,9 +4195,12 @@ static void __attribute__((constructor)) fio_lib_init(void) {
   {
 #ifdef _SC_OPEN_MAX
     capa = sysconf(_SC_OPEN_MAX);
+#elif defined(__MINGW32__)
+    capa = FD_SETSIZE;
 #elif defined(FOPEN_MAX)
     capa = FOPEN_MAX;
 #endif
+#ifndef __MINGW32__
     // try to maximize limits - collect max and set to max
     struct rlimit rlim = {.rlim_max = 0};
     if (getrlimit(RLIMIT_NOFILE, &rlim) == -1) {
@@ -3569,6 +4219,8 @@ static void __attribute__((constructor)) fio_lib_init(void) {
       if (capa > 1024) /* leave a slice of room */
         capa -= 16;
     }
+#endif
+
     /* initialize memory allocator */
     fio_mem_init();
     /* initialize polling engine */
@@ -3586,6 +4238,16 @@ static void __attribute__((constructor)) fio_lib_init(void) {
                   (capa * (sizeof(*fio_data->info)))),
                  (sizeof(*fio_data->poll) + sizeof(*fio_data->info)),
                  sizeof(*fio_data));
+#elif FIO_ENGINE_WSAPOLL
+    FIO_LOG_INFO("facil.io " FIO_VERSION_STRING " capacity initialization:\n"
+                 "*    Meximum open files %zu out of %zu\n"
+                 "*    Allocating %zu bytes for state handling.\n"
+                 "*    %zu bytes per connection + %zu for state handling.",
+                 capa, FOPEN_MAX,
+                 (sizeof(*fio_data) + (capa * (sizeof(*fio_data->poll))) +
+                  (capa * (sizeof(*fio_data->info)))),
+                 (sizeof(*fio_data->poll) + sizeof(*fio_data->info)),
+                 sizeof(*fio_data));
 #else
     FIO_LOG_INFO("facil.io " FIO_VERSION_STRING " capacity initialization:\n"
                  "*    Meximum open files %zu out of %zu\n"
@@ -3598,7 +4260,7 @@ static void __attribute__((constructor)) fio_lib_init(void) {
 #endif
   }
 
-#if FIO_ENGINE_POLL
+#if FIO_ENGINE_POLL || FIO_ENGINE_WSAPOLL
   /* allocate and initialize main data structures by detected capacity */
   fio_data = fio_mmap(sizeof(*fio_data) + (capa * (sizeof(*fio_data->poll))) +
                       (capa * (sizeof(*fio_data->info))));
@@ -3618,7 +4280,7 @@ static void __attribute__((constructor)) fio_lib_init(void) {
 
   for (ssize_t i = 0; i < capa; ++i) {
     fio_clear_fd(i, 0);
-#if FIO_ENGINE_POLL
+#if FIO_ENGINE_POLL || FIO_ENGINE_WSAPOLL
     fio_data->poll[i].fd = -1;
 #endif
   }
@@ -3915,25 +4577,33 @@ void fio_start FIO_IGNORE_MACRO(struct fio_start_args args) {
   fio_data->threads = (uint16_t)args.threads;
   fio_data->active = 1;
   fio_data->is_worker = 0;
-
+  
   fio_state_callback_force(FIO_CALL_PRE_START);
+#if HAVE_OPENSSL
   FIO_LOG_INFO(
       "Server is running %u %s X %u %s with facil.io " FIO_VERSION_STRING
       " (%s)\n"
-#if HAVE_OPENSSL
       "* Linked to %s\n"
-#endif
       "* Detected capacity: %d open file limit\n"
       "* Root pid: %d\n"
       "* Press ^C to stop\n",
       fio_data->workers, fio_data->workers > 1 ? "workers" : "worker",
       fio_data->threads, fio_data->threads > 1 ? "threads" : "thread",
       fio_engine(),
-#if HAVE_OPENSSL
       OpenSSL_version(0),
-#endif
       fio_data->capa, (int)fio_data->parent);
-
+#else
+  FIO_LOG_INFO(
+      "Server is running %u %s X %u %s with facil.io " FIO_VERSION_STRING
+      " (%s)\n"
+      "* Detected capacity: %d open file limit\n"
+      "* Root pid: %d\n"
+      "* Press ^C to stop\n",
+      fio_data->workers, fio_data->workers > 1 ? "workers" : "worker",
+      fio_data->threads, fio_data->threads > 1 ? "threads" : "thread",
+      fio_engine(),
+      fio_data->capa, (int)fio_data->parent);
+#endif
   if (args.workers > 1) {
     for (int i = 0; i < args.workers && fio_data->active; ++i) {
       fio_sentinel_task(NULL, NULL);
@@ -4359,7 +5029,7 @@ Section Start Marker
 
 
 ***************************************************************************** */
-
+ #ifndef __MINGW32__
 /**
  * Returns the number of registered ALPN protocol names.
  *
@@ -4433,6 +5103,7 @@ void FIO_TLS_WEAK fio_tls_destroy(void *tls) {
   return;
   (void)tls;
 }
+#endif
 
 /* *****************************************************************************
 Section Start Marker
@@ -4490,8 +5161,10 @@ typedef struct {
 
 static void fio_listen_cleanup_task(void *pr_) {
   fio_listen_protocol_s *pr = pr_;
+#ifndef __MINGW32__
   if (pr->tls)
     fio_tls_destroy(pr->tls);
+#endif
   if (pr->on_finish) {
     pr->on_finish(pr->uuid, pr->udata);
   }
@@ -4532,6 +5205,7 @@ static void fio_listen_on_data(intptr_t uuid, fio_protocol_s *pr_) {
   }
 }
 
+#ifndef __MINGW32__
 static void fio_listen_on_data_tls(intptr_t uuid, fio_protocol_s *pr_) {
   fio_listen_protocol_s *pr = (fio_listen_protocol_s *)pr_;
   for (int i = 0; i < 4; ++i) {
@@ -4552,6 +5226,7 @@ static void fio_listen_on_data_tls_alpn(intptr_t uuid, fio_protocol_s *pr_) {
     fio_tls_accept(client, pr->tls, pr->udata);
   }
 }
+#endif
 
 /* stub for editor - unused */
 void fio_listen____(void);
@@ -4562,11 +5237,19 @@ void fio_listen____(void);
  */
 intptr_t fio_listen FIO_IGNORE_MACRO(struct fio_listen_args args) {
   // ...
+#ifdef __MINGW32__
+  if ((!args.on_open) ||
+      (!args.address && !args.port)) {
+    errno = EINVAL;
+    goto error;
+  }
+#else
   if ((!args.on_open && (!args.tls || !fio_tls_alpn_count(args.tls))) ||
       (!args.address && !args.port)) {
     errno = EINVAL;
     goto error;
   }
+#endif
 
   size_t addr_len = 0;
   size_t port_len = 0;
@@ -4592,19 +5275,23 @@ intptr_t fio_listen FIO_IGNORE_MACRO(struct fio_listen_args args) {
   fio_listen_protocol_s *pr = malloc(sizeof(*pr) + addr_len + port_len +
                                      ((addr_len + port_len) ? 2 : 0));
   FIO_ASSERT_ALLOC(pr);
-
+#ifndef __MINGW32__
   if (args.tls)
     fio_tls_dup(args.tls);
-
+#endif
   *pr = (fio_listen_protocol_s){
       .pr =
           {
               .on_close = fio_listen_on_close,
               .ping = mock_ping_eternal,
+#ifdef __MINGW32__
+              .on_data = fio_listen_on_data,
+#else
               .on_data = (args.tls ? (fio_tls_alpn_count(args.tls)
                                           ? fio_listen_on_data_tls_alpn
                                           : fio_listen_on_data_tls)
                                    : fio_listen_on_data),
+#endif
           },
       .uuid = uuid,
       .udata = args.udata,
@@ -4696,8 +5383,10 @@ static void fio_connect_on_close(intptr_t uuid, fio_protocol_s *pr_) {
   fio_connect_protocol_s *pr = (fio_connect_protocol_s *)pr_;
   if (pr->on_fail)
     pr->on_fail(uuid, pr->udata);
+#ifndef __MINGW32__
   if (pr->tls)
     fio_tls_destroy(pr->tls);
+#endif
   fio_free(pr);
   (void)uuid;
 }
@@ -4713,6 +5402,7 @@ static void fio_connect_on_ready(intptr_t uuid, fio_protocol_s *pr_) {
   (void)uuid;
 }
 
+#ifndef __MINGW32__
 static void fio_connect_on_ready_tls(intptr_t uuid, fio_protocol_s *pr_) {
   fio_connect_protocol_s *pr = (fio_connect_protocol_s *)pr_;
   if (pr->pr.on_ready == mock_on_ev)
@@ -4735,16 +5425,25 @@ static void fio_connect_on_ready_tls_alpn(intptr_t uuid, fio_protocol_s *pr_) {
   fio_poll_add(fio_uuid2fd(uuid));
   (void)uuid;
 }
+#endif
 
 /* stub for sublime text function navigation */
 intptr_t fio_connect___(struct fio_connect_args args);
 
 intptr_t fio_connect FIO_IGNORE_MACRO(struct fio_connect_args args) {
+#ifdef __MINGW32__
+  if ((!args.on_connect) ||
+      (!args.address && !args.port)) {
+    errno = EINVAL;
+    goto error;
+  }
+#else
   if ((!args.on_connect && (!args.tls || !fio_tls_alpn_count(args.tls))) ||
       (!args.address && !args.port)) {
     errno = EINVAL;
     goto error;
   }
+#endif
   const intptr_t uuid = fio_socket(args.address, args.port, 0);
   if (uuid == -1)
     goto error;
@@ -4752,17 +5451,21 @@ intptr_t fio_connect FIO_IGNORE_MACRO(struct fio_connect_args args) {
 
   fio_connect_protocol_s *pr = fio_malloc(sizeof(*pr));
   FIO_ASSERT_ALLOC(pr);
-
+#ifndef __MINGW32__
   if (args.tls)
     fio_tls_dup(args.tls);
-
+#endif
   *pr = (fio_connect_protocol_s){
       .pr =
           {
+#ifdef __MINGW32__
+              .on_ready = fio_connect_on_ready,
+#else
               .on_ready = (args.tls ? (fio_tls_alpn_count(args.tls)
                                            ? fio_connect_on_ready_tls_alpn
                                            : fio_connect_on_ready_tls)
                                     : fio_connect_on_ready),
+#endif
               .on_close = fio_connect_on_close,
           },
       .uuid = uuid,
@@ -5136,7 +5839,7 @@ struct subscription_s {
   fio_lock_i unsubscribed;
 };
 
-/* Use `malloc` / `free`, because channles might have a long life. */
+/* Use `malloc` / `free`, because channels might have a long life. */
 
 /** Used internally by the Set object to create a new channel. */
 static channel_s *fio_channel_copy(channel_s *src) {
@@ -5391,6 +6094,7 @@ static channel_s *fio_filter_dup_lock(uint32_t filter) {
       .name_len = (sizeof(filter)),
       .parent = &fio_postoffice.filters,
       .ref = 8, /* avoid freeing stack memory */
+      .lock = FIO_LOCK_INIT,
   };
   return fio_filter_dup_lock_internal(&ch, filter, &fio_postoffice.filters);
 }
@@ -5402,6 +6106,7 @@ static channel_s *fio_channel_dup_lock(fio_str_info_s name) {
       .name_len = name.len,
       .parent = &fio_postoffice.pubsub,
       .ref = 8, /* avoid freeing stack memory */
+      .lock = FIO_LOCK_INIT,
   };
   uint64_t hashed_name = FIO_HASH_FN(
       name.data, name.len, &fio_postoffice.pubsub, &fio_postoffice.pubsub);
@@ -5422,6 +6127,7 @@ static channel_s *fio_channel_match_dup_lock(fio_str_info_s name,
       .parent = &fio_postoffice.patterns,
       .match = match,
       .ref = 8, /* avoid freeing stack memory */
+      .lock = FIO_LOCK_INIT,
   };
   uint64_t hashed_name = FIO_HASH_FN(
       name.data, name.len, &fio_postoffice.pubsub, &fio_postoffice.pubsub);
@@ -5448,7 +6154,7 @@ static inline void fio_subscription_free(subscription_s *s) {
 /** SublimeText 3 marker */
 subscription_s *fio_subscribe___(subscribe_args_s args);
 
-/** Subscribes to a filter, pub/sub channle or patten */
+/** Subscribes to a filter, pub/sub channel or pattern */
 subscription_s *fio_subscribe FIO_IGNORE_MACRO(subscribe_args_s args) {
   if (!args.on_message)
     goto error;
@@ -5480,7 +6186,7 @@ error:
   return NULL;
 }
 
-/** Unsubscribes from a filter, pub/sub channle or patten */
+/** Unsubscribes from a filter, pub/sub channel or pattern */
 void fio_unsubscribe(subscription_s *s) {
   if (!s)
     return;
@@ -5496,8 +6202,11 @@ void fio_unsubscribe(subscription_s *s) {
     fio_collection_s *c = ch->parent;
     uint64_t hashed = FIO_HASH_FN(
         ch->name, ch->name_len, &fio_postoffice.pubsub, &fio_postoffice.pubsub);
-    /* lock collection */
-    fio_lock(&c->lock);
+    /* lock collection,
+       need to try and throttle wait, to prevent deadlock with fio_subscribe */
+    while (fio_trylock(&c->lock)) {
+      fio_throttle_thread(100);
+    }
     /* test again within lock */
     if (fio_ls_embd_is_empty(&ch->subscriptions)) {
       fio_ch_set_remove(&c->channels, hashed, ch, NULL);
@@ -6230,8 +6939,12 @@ static void fio_listen2cluster(void *ignore) {
       .ping = mock_ping_eternal,
       .on_close = fio_cluster_listen_on_close,
   };
+#ifdef __MINGW32__
+  FIO_LOG_DEBUG("(%d) Listening to cluster on above tcp socket.", (int)getpid());
+#else
   FIO_LOG_DEBUG("(%d) Listening to cluster: %s", (int)getpid(),
                 cluster_data.name);
+#endif
   fio_attach(cluster_data.uuid, p);
   (void)ignore;
 }
@@ -6351,7 +7064,7 @@ static void fio_send2cluster(fio_msg_internal_s *m) {
 }
 
 /* *****************************************************************************
- * Propegation
+ * Propagation
  **************************************************************************** */
 
 static inline void fio_cluster_inform_root_about_channel(channel_s *ch,
@@ -6371,7 +7084,7 @@ static inline void fio_cluster_inform_root_about_channel(channel_s *ch,
 #endif
   char buf[8] = {0};
   if (ch->match) {
-    fio_u2str64(buf, (uint64_t)ch->match);
+    fio_u2str64(buf, (uintptr_t)ch->match);
     msg.data = buf;
     msg.len = sizeof(ch->match);
   }
@@ -7295,6 +8008,10 @@ static void fio_mem_init(void) {
   ssize_t cpu_count = 0;
 #ifdef _SC_NPROCESSORS_ONLN
   cpu_count = sysconf(_SC_NPROCESSORS_ONLN);
+#elif defined(__MINGW32__)
+  SYSTEM_INFO sys_info;
+  GetSystemInfo(&sys_info);
+  cpu_count = sys_info.dwNumberOfProcessors;
 #else
 #warning Dynamic CPU core count is unavailable - assuming 8 cores for memory allocation pools.
 #endif
@@ -7304,7 +8021,9 @@ static void fio_mem_init(void) {
   arenas = big_alloc(sizeof(*arenas) * cpu_count);
   FIO_ASSERT_ALLOC(arenas);
   block_free(block_new());
+#ifndef __MINGW32__
   pthread_atfork(NULL, NULL, fio_malloc_after_fork);
+#endif
 }
 
 static void fio_mem_destroy(void) {
@@ -9452,6 +10171,12 @@ FIO_FUNC void fio_socket_test(void) {
 
   fprintf(stderr, "=== Testing facil.io listening socket creation (partial "
                   "testing only).\n");
+#ifdef __MINGW32__
+  fprintf(stderr, "* testing on TCP/IP port 8765\n");
+  intptr_t uuid;
+  intptr_t client1;
+  intptr_t client2;
+#else
   fprintf(stderr, "* testing on TCP/IP port 8765 and Unix socket: %s\n",
           fio_str_data(&sock_name));
   intptr_t uuid = fio_socket(fio_str_data(&sock_name), NULL, 1);
@@ -9508,6 +10233,7 @@ FIO_FUNC void fio_socket_test(void) {
   unlink(fio_str_data(&sock_name));
   /* free unix socket name */
   fio_str_free(&sock_name);
+#endif
 
   uuid = fio_socket(NULL, "8765", 1);
   FIO_ASSERT(uuid != -1, "Failed to open TCP/IP socket on port 8765");
@@ -9718,7 +10444,7 @@ FIO_FUNC void fio_set_test(void) {
   FIO_ASSERT(!fio_set_test_last(&s), "empty set shouldn't have a last object");
   FIO_ASSERT(!fio_hash_test_last(&h).key && !fio_hash_test_last(&h).obj,
              "empty hash shouldn't have a last object");
-
+  
   for (uintptr_t i = 1; i < FIO_SET_TEST_COUNT; ++i) {
     fio_set_test_insert(&s, i, i);
     fio_hash_test_insert(&h, i, i, i + 1, NULL);
@@ -10496,7 +11222,7 @@ FIO_FUNC void fio_base64_test(void) {
       fprintf(stderr,
               ":\n--- fio Base64 Test FAILED!\nstring: %s\nlength: %lu\n "
               "expected: %s\ngot: %s\n\n",
-              sets[i].str, strlen(sets[i].str), sets[i].base64, buffer);
+              sets[i].str, (u_long)strlen(sets[i].str), sets[i].base64, buffer);
       FIO_ASSERT(0, "Base64 failure.");
     }
     i++;
@@ -10569,7 +11295,45 @@ FIO_FUNC void fio_test_random(void) {
 /* *****************************************************************************
 Poll (not kqueue or epoll) tests
 ***************************************************************************** */
-#if FIO_ENGINE_POLL
+#if FIO_ENGINE_POLL || FIO_ENGINE_WSAPOLL
+#ifdef __MINGW32__
+FIO_FUNC void fio_poll_test(void) {
+  fprintf(stderr, "=== Testing poll add / remove fd\n");
+  fio_poll_add(5);
+  FIO_ASSERT(fio_data->poll[5].fd == 5, "fio_poll_add didn't set used fd data");
+  FIO_ASSERT(fio_data->poll[5].events ==
+                 (FIO_POLL_READ_EVENTS | FIO_POLL_WRITE_EVENTS),
+             "fio_poll_add didn't set used fd flags");
+  fio_poll_add(7);
+  FIO_ASSERT(fio_data->poll[6].fd == INVALID_SOCKET,
+             "fio_poll_add didn't reset unused fd data %d",
+             fio_data->poll[6].fd);
+  fio_poll_add(6);
+  fio_poll_remove_fd(6);
+  FIO_ASSERT(fio_data->poll[6].fd == INVALID_SOCKET,
+             "fio_poll_remove_fd didn't reset unused fd data");
+  FIO_ASSERT(fio_data->poll[6].events == 0,
+             "fio_poll_remove_fd didn't reset unused fd flags");
+  fio_poll_remove_read(7);
+  FIO_ASSERT(fio_data->poll[7].events == (FIO_POLL_WRITE_EVENTS),
+             "fio_poll_remove_read didn't remove read flags");
+  fio_poll_add_read(7);
+  fio_poll_remove_write(7);
+  FIO_ASSERT(fio_data->poll[7].events == (FIO_POLL_READ_EVENTS),
+             "fio_poll_remove_write didn't remove read flags");
+  fio_poll_add_write(7);
+  fio_poll_remove_read(7);
+  FIO_ASSERT(fio_data->poll[7].events == (FIO_POLL_WRITE_EVENTS),
+             "fio_poll_add_write didn't add the write flag?");
+  fio_poll_remove_write(7);
+  FIO_ASSERT(fio_data->poll[7].fd == INVALID_SOCKET,
+             "fio_poll_remove (both) didn't reset unused fd data");
+  FIO_ASSERT(fio_data->poll[7].events == 0,
+             "fio_poll_remove (both) didn't reset unused fd flags");
+  fio_poll_remove_fd(5);
+  fprintf(stderr, "\n* passed.\n");
+}
+#else
 FIO_FUNC void fio_poll_test(void) {
   fprintf(stderr, "=== Testing poll add / remove fd\n");
   fio_poll_add(5);
@@ -10606,6 +11370,7 @@ FIO_FUNC void fio_poll_test(void) {
   fio_poll_remove_fd(5);
   fprintf(stderr, "\n* passed.\n");
 }
+#endif
 #else
 #define fio_poll_test()
 #endif
@@ -10831,7 +11596,7 @@ FIO_FUNC void fio_atol_test(void) {
     __asm__ volatile("" ::: "memory");
   }
   end = clock();
-  fprintf(stderr, "fio_atol base 10 (%ld): %zd CPU cycles\n", result,
+  fprintf(stderr, "fio_atol base 10 (%ld): %zd CPU cycles\n", (long int)result,
           end - start);
 
   result = 0;
@@ -10842,7 +11607,7 @@ FIO_FUNC void fio_atol_test(void) {
     __asm__ volatile("" ::: "memory");
   }
   end = clock();
-  fprintf(stderr, "native strtol base 10 (%ld): %zd CPU cycles\n", result,
+  fprintf(stderr, "native strtol base 10 (%ld): %zd CPU cycles\n", (long int)result,
           end - start);
 
   result = 0;
@@ -10854,7 +11619,7 @@ FIO_FUNC void fio_atol_test(void) {
     __asm__ volatile("" ::: "memory");
   }
   end = clock();
-  fprintf(stderr, "fio_atol base 16 (%ld): %zd CPU cycles\n", result,
+  fprintf(stderr, "fio_atol base 16 (%ld): %zd CPU cycles\n", (long int)result,
           end - start);
 
   result = 0;
@@ -10865,7 +11630,7 @@ FIO_FUNC void fio_atol_test(void) {
     __asm__ volatile("" ::: "memory");
   }
   end = clock();
-  fprintf(stderr, "native strtol base 16 (%ld): %zd CPU cycles%s\n", result,
+  fprintf(stderr, "native strtol base 16 (%ld): %zd CPU cycles%s\n", (long int)result,
           end - start, (result != expect ? " (!?stdlib overflow?!)" : ""));
 
   result = 0;
@@ -10889,7 +11654,7 @@ FIO_FUNC void fio_atol_test(void) {
   start = clock();
   for (size_t i = 0; i < FIO_ATOL_TEST_MAX_CYCLES; ++i) {
     __asm__ volatile("" ::: "memory");
-    sprintf(number, "%ld", expect);
+    sprintf(number, "%ld", (long int)expect);
     __asm__ volatile("" ::: "memory");
   }
   end = clock();

--- a/ext/iodine/fio.h
+++ b/ext/iodine/fio.h
@@ -266,6 +266,7 @@ int fork(void);
 int kill(int, int);
 ssize_t pread(int, void*, size_t, off_t);
 ssize_t pwrite(int, const void *, size_t, off_t);
+SOCKET fio_handle4fd(unsigned int);
 #endif
 
 /* *****************************************************************************

--- a/ext/iodine/fio.h
+++ b/ext/iodine/fio.h
@@ -6317,7 +6317,7 @@ restart:
     FIO_LOG_FATAL(
         "facil.io Set / Hash Map has too many collisions (%zu/%zu)."
         "\n\t\tthis is a fatal implementation error,"
-        "please report this issue at facio.io's open source project"
+        "please report this issue at facil.io's open source project"
         "\n\t\tNote: hash maps and sets should never reach this point."
         "\n\t\tThey should be guarded against collision attacks.",
         set->pos, set->capa);

--- a/ext/iodine/fio.h
+++ b/ext/iodine/fio.h
@@ -266,7 +266,7 @@ int fork(void);
 int kill(int, int);
 ssize_t pread(int, void*, size_t, off_t);
 ssize_t pwrite(int, const void *, size_t, off_t);
-SOCKET fio_handle4fd(unsigned int);
+int fio_osffd4fd(unsigned int);
 #endif
 
 /* *****************************************************************************

--- a/ext/iodine/fio.h
+++ b/ext/iodine/fio.h
@@ -215,8 +215,15 @@ Version and helper macros
 
 #include <fcntl.h>
 #include <sys/stat.h>
+#ifndef __MINGW32__
 #include <sys/time.h>
+#endif
 #include <unistd.h>
+#ifdef __MINGW32__
+#include <winsock2.h>
+#include <winsock.h>
+#include <ws2tcpip.h>
+#endif
 
 #if !defined(__GNUC__) && !defined(__clang__) && !defined(FIO_GNUC_BYPASS)
 #define __attribute__(...)
@@ -241,6 +248,24 @@ Version and helper macros
 #if defined(__FreeBSD__)
 #include <netinet/in.h>
 #include <sys/socket.h>
+#endif
+
+#ifdef __MINGW32__
+#define	__S_IFMT	              0170000
+#define __S_IFLNK               0120000
+#define	__S_ISTYPE(mode, mask)	(((mode) & __S_IFMT) == (mask))
+#define S_ISLNK(mode)	          __S_ISTYPE((mode), __S_IFLNK)
+
+#define SIGKILL 9
+#define SIGTERM 15
+#define SIGCONT 17
+
+#define pipe(fds) _pipe(fds, 65536, _O_BINARY)
+
+int fork(void);
+int kill(int, int);
+ssize_t pread(int, void*, size_t, off_t);
+ssize_t pwrite(int, const void *, size_t, off_t);
 #endif
 
 /* *****************************************************************************
@@ -2068,7 +2093,7 @@ FIO_FUNC inline int fio_trylock(fio_lock_i *lock);
 /**
  * Releases a spinlock. Releasing an unacquired lock will break it.
  *
- * Returns a non-zero value on success, or 0 if the lock was in an unloacked
+ * Returns a non-zero value on success, or 0 if the lock was in an unlocked
  * state.
  */
 FIO_FUNC inline int fio_unlock(fio_lock_i *lock);
@@ -2539,8 +2564,9 @@ FIO_FUNC inline uint64_t fio_risky_hash(const void *data_, size_t len,
   uint64_t result = fio_lrot64(v0, 17) + fio_lrot64(v1, 13) +
                     fio_lrot64(v2, 47) + fio_lrot64(v3, 57);
 
-  len ^= (len << 33);
-  result += len;
+  uint64_t len64 = len;
+  len64 ^= (len64 << 33);
+  result += len64;
 
   result += v0 * RISKY_PRIME_1;
   result ^= fio_lrot64(result, 13);
@@ -2931,9 +2957,9 @@ C++ extern end
 /**
  * The logarithmic value for a memory block, 15 == 32Kb, 16 == 64Kb, etc'
  *
- * By default, a block of memory is 32Kb silce from an 8Mb allocation.
+ * By default, a block of memory is a 32Kb slice from an 8Mb allocation.
  *
- * A value of 16 will make this a 64Kb silce from a 16Mb allocation.
+ * A value of 16 will make this a 64Kb slice from a 16Mb allocation.
  */
 #define FIO_MEMORY_BLOCK_SIZE_LOG (15)
 #endif
@@ -3000,7 +3026,7 @@ FIO_FUNC inline int fio_trylock(fio_lock_i *lock) {
 /**
  * Releases a spinlock. Releasing an unacquired lock will break it.
  *
- * Returns a non-zero value on success, or 0 if the lock was in an unloacked
+ * Returns a non-zero value on success, or 0 if the lock was in an unlocked
  * state.
  */
 FIO_FUNC inline int fio_unlock(fio_lock_i *lock) {
@@ -3864,6 +3890,7 @@ FIO_FUNC char *fio_str_detach(fio_str_s *s) {
     }
     /* make a copy */
     void *tmp = FIO_MALLOC(i.len + 1);
+    FIO_ASSERT_ALLOC(tmp);
     memcpy(tmp, i.data, i.len + 1);
     i.data = tmp;
   } else {
@@ -3874,6 +3901,7 @@ FIO_FUNC char *fio_str_detach(fio_str_s *s) {
     } else if (s->dealloc != FIO_FREE) {
       /* make a copy */
       void *tmp = FIO_MALLOC(i.len + 1);
+      FIO_ASSERT_ALLOC(tmp);
       memcpy(tmp, i.data, i.len + 1);
       i.data = tmp;
       if (s->dealloc)
@@ -4338,7 +4366,7 @@ inline FIO_FUNC fio_str_info_s fio_str_write_i(fio_str_s *s, int64_t num) {
   fio_str_info_s i;
   if (!num)
     goto zero;
-  char buf[22];
+  char buf[22] = {0};
   uint64_t l = 0;
   uint8_t neg;
   if ((neg = (num < 0))) {
@@ -4472,7 +4500,7 @@ FIO_FUNC fio_str_info_s fio_str_readfile(fio_str_s *s, const char *filename,
                                          intptr_t start_at, intptr_t limit) {
   fio_str_info_s state = {.data = NULL};
 #if defined(__unix__) || defined(__linux__) || defined(__APPLE__) ||           \
-    defined(__CYGWIN__)
+    defined(__CYGWIN__) || defined(__MINGW32__)
   /* POSIX implementations. */
   if (filename == NULL || !s)
     return state;
@@ -4502,7 +4530,7 @@ FIO_FUNC fio_str_info_s fio_str_readfile(fio_str_s *s, const char *filename,
     }
   }
 
-  if (stat(filename, &f_data)) {
+  if (stat(filename, &f_data) == -1) {
     goto finish;
   }
 
@@ -4510,9 +4538,12 @@ FIO_FUNC fio_str_info_s fio_str_readfile(fio_str_s *s, const char *filename,
     state = fio_str_info(s);
     goto finish;
   }
-
+#ifdef __MINGW32__
+  file = _open(filename, O_RDONLY);
+#else
   file = open(filename, O_RDONLY);
-  if (-1 == file)
+#endif
+  if (file == -1)
     goto finish;
 
   if (start_at < 0) {
@@ -4531,7 +4562,11 @@ FIO_FUNC fio_str_info_s fio_str_readfile(fio_str_s *s, const char *filename,
     state.data = NULL;
     state.len = state.capa = 0;
   }
+#ifdef __MINGW32__
+  _close(file);
+#else
   close(file);
+#endif
 finish:
   FIO_FREE(path);
   return state;
@@ -6012,7 +6047,7 @@ FIO_NAME(_insert_or_overwrite_)(FIO_NAME(s) * set, FIO_SET_HASH_TYPE hash_value,
   pos->hash = hash_value;
   pos->pos->hash = hash_value;
   FIO_SET_COPY(pos->pos->obj, obj);
-
+  
   return pos->pos->obj;
 }
 

--- a/ext/iodine/fio_cli.c
+++ b/ext/iodine/fio_cli.c
@@ -50,7 +50,7 @@ typedef struct {
 #define AVOID_MACRO
 
 #define FIO_CLI_HASH_VAL(s)                                                    \
-  fio_risky_hash((s).data, (s).len, (uint64_t)fio_cli_start)
+  fio_risky_hash((s).data, (s).len, (uintptr_t)fio_cli_start)
 
 /* *****************************************************************************
 CLI Parsing

--- a/ext/iodine/fio_tls_missing.c
+++ b/ext/iodine/fio_tls_missing.c
@@ -4,6 +4,13 @@ License: MIT
 
 Feel free to copy, use and enjoy according to the license provided.
 */
+#ifdef __MINGW32__
+// make pedantic compiler happy
+typedef struct {
+  int bogus;
+} bogus_s;
+
+#else
 #include <fio.h>
 
 /**
@@ -639,3 +646,4 @@ void FIO_TLS_WEAK fio_tls_destroy(fio_tls_s *tls) {
 }
 
 #endif /* Library compiler flags */
+#endif

--- a/ext/iodine/fio_tls_openssl.c
+++ b/ext/iodine/fio_tls_openssl.c
@@ -4,6 +4,13 @@ License: MIT
 
 Feel free to copy, use and enjoy according to the license provided.
 */
+#ifdef __MINGW32__
+// make pedantic compiler happy
+typedef struct {
+  int bogus;
+} bogus_s;
+
+#else
 #include <fio.h>
 
 /**
@@ -1046,3 +1053,4 @@ void FIO_TLS_WEAK fio_tls_destroy(fio_tls_s *tls) {
 }
 
 #endif /* Library compiler flags */
+#endif

--- a/ext/iodine/fio_tmpfile.h
+++ b/ext/iodine/fio_tmpfile.h
@@ -18,10 +18,22 @@ License: MIT
 #include <sys/types.h>
 #include <unistd.h>
 
+#ifdef __MINGW32__
+#include <fileapi.h>
+#endif
+
 static inline int fio_tmpfile(void) {
   // create a temporary file to contain the data.
   int fd = 0;
-#ifdef P_tmpdir
+#ifdef __MINGW32__
+  char name_template[] = "fio";
+  TCHAR temp_path[(MAX_PATH-14)];
+  TCHAR temp_filename[MAX_PATH];
+  GetTempPath(MAX_PATH - 14, temp_path);
+  GetTempFileNameA(temp_path, name_template, 0, temp_filename);
+  fd = _open(temp_filename, _O_CREAT | _O_RDWR);
+  _chmod(temp_filename, _S_IREAD | _S_IWRITE);
+#elif defined(P_tmpdir)
   if (P_tmpdir[sizeof(P_tmpdir) - 1] == '/') {
     char name_template[] = P_tmpdir "facil_io_tmpfile_XXXXXXXX";
     fd = mkstemp(name_template);

--- a/ext/iodine/fiobj_data.c
+++ b/ext/iodine/fiobj_data.c
@@ -1,5 +1,5 @@
 #if defined(__unix__) || defined(__APPLE__) || defined(__linux__) ||           \
-    defined(__CYGWIN__) /* require POSIX */
+    defined(__CYGWIN__) || defined(__MINGW32__) /* require POSIX */
 /*
 Copyright: Boaz Segev, 2017-2019
 License: MIT
@@ -78,6 +78,7 @@ static void fiobj_data_copy_parent(FIOBJ o) {
   switch (obj2io(obj2io(o)->source.parent)->fd) {
   case -1:
     obj2io(o)->buffer = fio_malloc(obj2io(o)->len + 1);
+    FIO_ASSERT_ALLOC(obj2io(o)->buffer);
     memcpy(obj2io(o)->buffer,
            obj2io(obj2io(o)->source.parent)->buffer + obj2io(o)->capa,
            obj2io(o)->len);
@@ -102,7 +103,11 @@ static void fiobj_data_copy_parent(FIOBJ o) {
       if (data.len + pos > obj2io(o)->len)
         data.len = obj2io(o)->len - pos;
     retry_int:
+#ifdef __MINGW32__
+      written = pwrite(obj2io(o)->fd, data.data, data.len, 0);
+#else
       written = write(obj2io(o)->fd, data.data, data.len);
+#endif
       if (written < 0) {
         if (errno == EINTR)
           goto retry_int;

--- a/ext/iodine/fiobj_data.c
+++ b/ext/iodine/fiobj_data.c
@@ -955,24 +955,28 @@ void fiobj_data_assert_dynamic(FIOBJ io) {
  * Behaves and returns the same value as the system call `write`.
  */
 intptr_t fiobj_data_write(FIOBJ io, void *buffer, uintptr_t length) {
+  fprintf(stderr, "fiobj_data_write 1 io: %u buffer: %u length: %u\n", io, buffer, length);
   if (!io || !FIOBJ_TYPE_IS(io, FIOBJ_T_DATA) || (!buffer && length)) {
+    fprintf(stderr, "fiobj_data_write error\n");
     errno = EFAULT;
     return -1;
   }
+  fprintf(stderr, "fiobj_data_write 2\n");
   errno = 0;
   /* Unslice slices */
   if (obj2io(io)->fd == -2)
     fiobj_data_assert_dynamic(io);
-
+  fprintf(stderr, "fiobj_data_write 3\n");
   if (obj2io(io)->fd == -1) {
     /* String Code */
     fiobj_data_pre_write(io, length + 1);
     memcpy(obj2io(io)->buffer + obj2io(io)->len, buffer, length);
     obj2io(io)->len = obj2io(io)->len + length;
     obj2io(io)->buffer[obj2io(io)->len] = 0;
+    fprintf(stderr, "fiobj_data_write '%s'\n", obj2io(io)->buffer);
     return length;
   }
-
+  fprintf(stderr, "fiobj_data_write 4\n");
   /* File Code */
   return pwrite(obj2io(io)->fd, buffer, length, fiobj_data_get_fd_size(io));
 }

--- a/ext/iodine/fiobj_data.c
+++ b/ext/iodine/fiobj_data.c
@@ -955,28 +955,22 @@ void fiobj_data_assert_dynamic(FIOBJ io) {
  * Behaves and returns the same value as the system call `write`.
  */
 intptr_t fiobj_data_write(FIOBJ io, void *buffer, uintptr_t length) {
-  fprintf(stderr, "fiobj_data_write 1 io: %u buffer: %u length: %u\n", io, buffer, length);
   if (!io || !FIOBJ_TYPE_IS(io, FIOBJ_T_DATA) || (!buffer && length)) {
-    fprintf(stderr, "fiobj_data_write error\n");
     errno = EFAULT;
     return -1;
   }
-  fprintf(stderr, "fiobj_data_write 2\n");
   errno = 0;
   /* Unslice slices */
   if (obj2io(io)->fd == -2)
     fiobj_data_assert_dynamic(io);
-  fprintf(stderr, "fiobj_data_write 3\n");
   if (obj2io(io)->fd == -1) {
     /* String Code */
     fiobj_data_pre_write(io, length + 1);
     memcpy(obj2io(io)->buffer + obj2io(io)->len, buffer, length);
     obj2io(io)->len = obj2io(io)->len + length;
     obj2io(io)->buffer[obj2io(io)->len] = 0;
-    fprintf(stderr, "fiobj_data_write '%s'\n", obj2io(io)->buffer);
     return length;
   }
-  fprintf(stderr, "fiobj_data_write 4\n");
   /* File Code */
   return pwrite(obj2io(io)->fd, buffer, length, fiobj_data_get_fd_size(io));
 }
@@ -1055,7 +1049,6 @@ void fiobj_data_test(void) {
     fprintf(stderr, "* `fiobj_data_read` operation overflow - FAILED!\n");
     exit(-1);
   }
-
   if (fiobj_obj2cstr(strio).len != fiobj_obj2cstr(text).len ||
       fiobj_obj2cstr(fdio).len != fiobj_obj2cstr(text).len) {
     fprintf(stderr, "* `write` operation FAILED!\n");

--- a/ext/iodine/fiobj_data.h
+++ b/ext/iodine/fiobj_data.h
@@ -3,7 +3,8 @@ Copyright: Boaz Segev, 2017-2019
 License: MIT
 */
 #if !defined(H_FIOBJ_IO_H) && (defined(__unix__) || defined(__APPLE__) ||      \
-                               defined(__linux__) || defined(__CYGWIN__))
+                               defined(__linux__) || defined(__CYGWIN__) ||    \
+                               defined(__MINGW32__))
 
 /**
  * A dynamic type for reading / writing to a local file,  a temporary file or an

--- a/ext/iodine/fiobj_hash.c
+++ b/ext/iodine/fiobj_hash.c
@@ -36,6 +36,8 @@ License: MIT
 
 #include <errno.h>
 
+#include <pthread.h>
+
 /* *****************************************************************************
 Hash types
 ***************************************************************************** */
@@ -69,18 +71,28 @@ static void fiobj_hash_dealloc(FIOBJ o, void (*task)(FIOBJ, void *),
   fio_free(FIOBJ2PTR(o));
 }
 
-static __thread FIOBJ each_at_key = FIOBJ_INVALID;
+static pthread_key_t each_at_key;
+static pthread_once_t each_at_key_once = PTHREAD_ONCE_INIT;
+static void init_each_at_key(void) {
+  FIOBJ *eak = malloc(sizeof(FIOBJ));
+  FIO_ASSERT_ALLOC(eak);
+  pthread_key_create(&each_at_key, free);
+  *eak = FIOBJ_INVALID;
+  pthread_setspecific(each_at_key, eak);
+}
 
 static size_t fiobj_hash_each1(FIOBJ o, size_t start_at,
                                int (*task)(FIOBJ obj, void *arg), void *arg) {
   assert(o && FIOBJ_TYPE_IS(o, FIOBJ_T_HASH));
-  FIOBJ old_each_at_key = each_at_key;
+  pthread_once(&each_at_key_once, init_each_at_key);
+  FIOBJ *each_at_key_ptr = (FIOBJ *)pthread_getspecific(each_at_key);
+  FIOBJ old_each_at_key = *each_at_key_ptr;
   fio_hash___s *hash = &obj2hash(o)->hash;
   size_t count = 0;
   if (hash->count == hash->pos) {
     /* no holes in the hash, we can work as we please. */
     for (count = start_at; count < hash->count; ++count) {
-      each_at_key = hash->ordered[count].obj.key;
+      *each_at_key_ptr = hash->ordered[count].obj.key;
       if (task((FIOBJ)hash->ordered[count].obj.obj, arg) == -1) {
         ++count;
         goto end;
@@ -100,13 +112,13 @@ static size_t fiobj_hash_each1(FIOBJ o, size_t start_at,
       if (hash->ordered[pos].obj.key == FIOBJ_INVALID)
         continue;
       ++count;
-      each_at_key = hash->ordered[pos].obj.key;
+      *each_at_key_ptr = hash->ordered[pos].obj.key;
       if (task((FIOBJ)hash->ordered[pos].obj.obj, arg) == -1)
         break;
     }
   }
 end:
-  each_at_key = old_each_at_key;
+  *each_at_key_ptr = old_each_at_key;
   return count;
 }
 

--- a/ext/iodine/fiobj_numbers.c
+++ b/ext/iodine/fiobj_numbers.c
@@ -40,6 +40,7 @@ static pthread_once_t num_vt_buffer_once = PTHREAD_ONCE_INIT;
 static void init_num_vt_buffer_key(void) {
   char *num_vt_buffer = malloc(sizeof(char)*512);
   FIO_ASSERT_ALLOC(num_vt_buffer);
+  memset(num_vt_buffer, 0, sizeof(char)*512);
   pthread_key_create(&num_vt_buffer_key, free);
   pthread_setspecific(num_vt_buffer_key, num_vt_buffer);
 }
@@ -144,6 +145,7 @@ static pthread_once_t num_ret_once = PTHREAD_ONCE_INIT;
 static void init_num_ret_key(void) {
   fiobj_num_s *ret = malloc(sizeof(fiobj_num_s));
   FIO_ASSERT_ALLOC(ret);
+  memset(ret, 0, sizeof(fiobj_num_s));
   pthread_key_create(&num_ret_key, free);
   pthread_setspecific(num_ret_key, ret);
 }
@@ -191,6 +193,7 @@ static pthread_once_t float_ret_once = PTHREAD_ONCE_INIT;
 static void init_float_ret_key(void) {
   fiobj_float_s *ret = malloc(sizeof(fiobj_float_s));
   FIO_ASSERT_ALLOC(ret);
+  memset(ret, 0, sizeof(fiobj_float_s));
   pthread_key_create(&float_ret_key, free);
   pthread_setspecific(float_ret_key, ret);
 }
@@ -218,6 +221,7 @@ static pthread_once_t num_str_buffer_once = PTHREAD_ONCE_INIT;
 static void init_num_str_buffer_key(void) {
   char *num_str_buffer = malloc(sizeof(char)*512);
   FIO_ASSERT_ALLOC(num_str_buffer);
+  memset(num_str_buffer, 0, sizeof(char)*512);
   pthread_key_create(&num_str_buffer_key, free);
   pthread_setspecific(num_str_buffer_key, num_str_buffer);
 }

--- a/ext/iodine/fiobject.c
+++ b/ext/iodine/fiobject.c
@@ -102,7 +102,7 @@ size_t __attribute__((weak)) fio_ltoa(char *dest, int64_t num, uint8_t base) {
                            '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
 
   size_t len = 0;
-  char buf[48]; /* we only need up to 20 for base 10, but base 3 needs 41... */
+  char buf[48] = {0}; /* we only need up to 20 for base 10, but base 3 needs 41... */
 
   if (!num)
     goto zero;

--- a/ext/iodine/fiobject.h
+++ b/ext/iodine/fiobject.h
@@ -502,7 +502,7 @@ fio_str_info_s fio_ftocstr(double);
 /**
  * Returns a C String (NUL terminated) using the `fio_str_info_s` data type.
  *
- * The Sting in binary safe and might contain NUL bytes in the middle as well as
+ * The String is binary safe and might contain NUL bytes in the middle as well as
  * a terminating NUL.
  *
  * If a a Number or a Float are passed to the function, they

--- a/ext/iodine/fiobject.h
+++ b/ext/iodine/fiobject.h
@@ -554,11 +554,13 @@ FIO_INLINE uint64_t fiobj_obj2hash(const FIOBJ o) {
   if (!FIOBJ_IS_ALLOCATED(o))
     return (uint64_t)o;
   fio_str_info_s s = fiobj_obj2cstr(o);
-  return FIO_HASH_FN(s.data, s.len, &fiobj_each2, &fiobj_free_complex_object);
+  return FIO_HASH_FN(s.data, s.len, (uintptr_t)&fiobj_each2,
+                     (uintptr_t)&fiobj_free_complex_object);
 }
 
 FIO_INLINE uint64_t fiobj_hash_string(const void *data, size_t len) {
-  return FIO_HASH_FN(data, len, &fiobj_each2, &fiobj_free_complex_object);
+  return FIO_HASH_FN(data, len, (uintptr_t)&fiobj_each2,
+                     (uintptr_t)&fiobj_free_complex_object);
 }
 
 /**

--- a/ext/iodine/http.c
+++ b/ext/iodine/http.c
@@ -99,6 +99,7 @@ static inline void add_date(http_s *r) {
   if (fio_last_tick().tv_sec > last_date_added) {
     fio_lock(&date_lock);
     if (fio_last_tick().tv_sec > last_date_added) { /* retest inside lock */
+      /* 32 chars are ok for a while, but http_time2str below has a buffer sized 48 chars and does a memcpy ... */
       FIOBJ tmp = fiobj_str_buf(32);
       FIOBJ old = current_date;
       fiobj_str_resize(
@@ -2348,9 +2349,12 @@ static pthread_once_t cached_once = PTHREAD_ONCE_INIT;
 static void init_cached_key(void) {
   time_t *cached_tick = malloc(sizeof(time_t));
   FIO_ASSERT_ALLOC(cached_tick);
+  memset(cached_tick, 0, sizeof(time_t));
   char *cached_httpdate = malloc(sizeof(char)*48);
   FIO_ASSERT_ALLOC(cached_tick);
+  memset(cached_httpdate, 0, 48);
   size_t *cached_len = malloc(sizeof(size_t));
+  *cached_len = 0;
   FIO_ASSERT_ALLOC(cached_len);
   pthread_key_create(&cached_tick_key, free);
   pthread_key_create(&cached_httpdate_key, free);
@@ -2554,6 +2558,7 @@ static pthread_once_t buffer_once = PTHREAD_ONCE_INIT;
 static void init_buffer_key(void) {
   char *buffer = malloc(sizeof(char) * (LONGEST_FILE_EXTENSION_LENGTH + 1));
   FIO_ASSERT_ALLOC(buffer);
+  memset(buffer, 0, sizeof(char) * (LONGEST_FILE_EXTENSION_LENGTH + 1));
   pthread_key_create(&buffer_key, free);
   pthread_setspecific(buffer_key, buffer);
 }

--- a/ext/iodine/http1.c
+++ b/ext/iodine/http1.c
@@ -375,6 +375,7 @@ static int http1_http2websocket_client(http_s *h, websocket_settings_s *args) {
     p->p.settings->on_finish(p->p.settings);
   /* Copy the Websocket setting arguments to the HTTP settings `udata` */
   p->p.settings->udata = fio_malloc(sizeof(*args));
+  FIO_ASSERT_ALLOC(p->p.settings->udata);
   ((websocket_settings_s *)(p->p.settings->udata))[0] = *args;
   /* Set callbacks */
   p->p.settings->on_finish = http1_websocket_client_on_hangup;   /* unknown */
@@ -820,7 +821,7 @@ void http1_destroy(fio_protocol_s *pr) {
   http_s_destroy(&http1_pr2handle(p), 0);
   // FIO_LOG_DEBUG("Deallocating HTTP/1.1 protocol %p(%d)=>%p", (void
   // *)p->p.uuid, (int)fio_uuid2fd(p->p.uuid), (void *)p);
-  fio_free(p);
+  fio_free(p); // occasional Windows crash bug
 }
 
 /* *****************************************************************************

--- a/ext/iodine/http_internal.c
+++ b/ext/iodine/http_internal.c
@@ -98,6 +98,7 @@ int http_send_error2(size_t error, intptr_t uuid, http_settings_s *settings) {
     return -1;
   fio_protocol_s *pr = http1_new(uuid, settings, NULL, 0);
   http_s *r = fio_malloc(sizeof(*r));
+  FIO_ASSERT_ALLOC(r);
   FIO_ASSERT(pr, "Couldn't allocate response object for error report.")
   http_s_new(r, (http_fio_protocol_s *)pr, http1_vtable());
   int ret = http_send_error(r, error);

--- a/ext/iodine/http_internal.h
+++ b/ext/iodine/http_internal.h
@@ -15,7 +15,9 @@ Feel free to copy, use and enjoy according to the license provided.
 
 #include <http.h>
 
+#ifndef __MINGW32__
 #include <arpa/inet.h>
+#endif
 #include <errno.h>
 
 /* *****************************************************************************
@@ -121,8 +123,8 @@ static inline void http_s_destroy(http_s *h, uint8_t log) {
   fiobj_free(h->params);
 
   *h = (http_s){
-      .private_data.vtbl = h->private_data.vtbl,
-      .private_data.flag = h->private_data.flag,
+    .private_data.vtbl = h->private_data.vtbl,
+    .private_data.flag = h->private_data.flag,
   };
 }
 

--- a/ext/iodine/iodine.h
+++ b/ext/iodine/iodine.h
@@ -15,7 +15,9 @@ typedef struct {
   fio_str_info_s body;
   fio_str_info_s public;
   fio_str_info_s url;
+#ifndef __MINGW32__
   fio_tls_s *tls;
+#endif
   VALUE handler;
   FIOBJ headers;
   FIOBJ cookies;

--- a/ext/iodine/iodine_caller.c
+++ b/ext/iodine/iodine_caller.c
@@ -10,8 +10,13 @@
 static pthread_key_t iodine_GVL_state_key;
 static pthread_once_t iodine_GVL_state_once = PTHREAD_ONCE_INIT;
 static void init_iodine_GVL_state_key(void) {
-  pthread_key_create(&iodine_GVL_state_key, NULL);
-  pthread_setspecific(iodine_GVL_state_key, (void *)1);
+  pthread_key_create(&iodine_GVL_state_key, NULL); 
+}
+static void init_iodine_GVL_state_init(void) {
+  uint8_t *gvl = malloc(sizeof(uint8_t));
+  FIO_ASSERT_ALLOC(gvl);
+  *gvl = 1;
+  pthread_setspecific(iodine_GVL_state_key, gvl);
 }
 
 /* *****************************************************************************
@@ -92,26 +97,36 @@ API
 /** Calls a C function within the GVL. */
 static void *iodine_enterGVL(void *(*func)(void *), void *arg) {
   pthread_once(&iodine_GVL_state_once, init_iodine_GVL_state_key);
-  if (pthread_getspecific(iodine_GVL_state_key)) {
+  uint8_t *iodine_GVL_state = pthread_getspecific(iodine_GVL_state_key);
+  if (!iodine_GVL_state) {
+    init_iodine_GVL_state_init();
+    iodine_GVL_state = pthread_getspecific(iodine_GVL_state_key);
+  }
+  if (*iodine_GVL_state) {
     return func(arg);
   }
   void *rv = NULL;
-  pthread_setspecific(iodine_GVL_state_key, (void *)1);
+  *iodine_GVL_state = 1;
   rv = rb_thread_call_with_gvl(func, arg);
-  pthread_setspecific(iodine_GVL_state_key, (void *)0);
+  *iodine_GVL_state = 0;
   return rv;
 }
 
 /** Calls a C function outside the GVL. */
 static void *iodine_leaveGVL(void *(*func)(void *), void *arg) {
   pthread_once(&iodine_GVL_state_once, init_iodine_GVL_state_key);
-  if (!pthread_getspecific(iodine_GVL_state_key)) {
+  uint8_t *iodine_GVL_state = pthread_getspecific(iodine_GVL_state_key);
+  if (!iodine_GVL_state) {
+    init_iodine_GVL_state_init();
+    iodine_GVL_state = pthread_getspecific(iodine_GVL_state_key);
+  }
+  if (!*iodine_GVL_state) {
     return func(arg);
   }
   void *rv = NULL;
-  pthread_setspecific(iodine_GVL_state_key, (void *)0);
+  *iodine_GVL_state = 0;
   rv = rb_thread_call_without_gvl(func, arg, NULL, NULL);
-  pthread_setspecific(iodine_GVL_state_key, (void *)1);
+  *iodine_GVL_state = 1;
   return rv;
 }
 
@@ -162,13 +177,23 @@ static VALUE iodine_call_block(VALUE obj, ID method, int argc, VALUE *argv,
 /** Returns the GVL state flag. */
 static uint8_t iodine_in_GVL(void) {
   pthread_once(&iodine_GVL_state_once, init_iodine_GVL_state_key);
-  return (uint8_t)pthread_getspecific(iodine_GVL_state_key);
+  uint8_t *iodine_GVL_state = pthread_getspecific(iodine_GVL_state_key);
+  if (!iodine_GVL_state) {
+    init_iodine_GVL_state_init();
+    iodine_GVL_state = pthread_getspecific(iodine_GVL_state_key);
+  }
+  return *iodine_GVL_state;
 }
 
 /** Forces the GVL state flag. */
 static void iodine_set_GVL(uint8_t state) { 
   pthread_once(&iodine_GVL_state_once, init_iodine_GVL_state_key);
-  pthread_setspecific(iodine_GVL_state_key, (void *)state);
+  uint8_t *iodine_GVL_state = pthread_getspecific(iodine_GVL_state_key);
+  if (!iodine_GVL_state) {
+    init_iodine_GVL_state_init();
+    iodine_GVL_state = pthread_getspecific(iodine_GVL_state_key);
+  }
+  *iodine_GVL_state = state;
 }
 
 /* *****************************************************************************

--- a/ext/iodine/iodine_http.c
+++ b/ext/iodine/iodine_http.c
@@ -942,6 +942,15 @@ intptr_t iodine_http_listen(iodine_connection_args_s args){
     support_xsendfile = 1;
   }
   IodineStore.add(args.handler);
+  #ifdef __MINGW32__
+    intptr_t uuid = http_listen(
+      args.port.data, args.address.data, .on_request = on_rack_request,
+      .on_upgrade = on_rack_upgrade, .udata = (void *)args.handler,
+      .timeout = args.timeout, .ws_timeout = args.ping,
+      .ws_max_msg_size = args.max_msg, .max_header_size = args.max_headers,
+      .on_finish = free_iodine_http, .log = args.log,
+      .max_body_size = args.max_body, .public_folder = args.public.data);
+  #else
   intptr_t uuid = http_listen(
       args.port.data, args.address.data, .on_request = on_rack_request,
       .on_upgrade = on_rack_upgrade, .udata = (void *)args.handler,
@@ -949,6 +958,7 @@ intptr_t iodine_http_listen(iodine_connection_args_s args){
       .ws_max_msg_size = args.max_msg, .max_header_size = args.max_headers,
       .on_finish = free_iodine_http, .log = args.log,
       .max_body_size = args.max_body, .public_folder = args.public.data);
+  #endif
   if (uuid == -1)
     return uuid;
 
@@ -1058,9 +1068,11 @@ intptr_t iodine_ws_connect(iodine_connection_args_s args) {
   FIOBJ url_tmp = FIOBJ_INVALID;
   if (!args.url.data) {
     url_tmp = fiobj_str_buf(64);
+  #ifndef __MINGW32__
     if (args.tls)
       fiobj_str_write(url_tmp, "wss://", 6);
     else
+  #endif
       fiobj_str_write(url_tmp, "ws://", 5);
     if (!is_unix_socket) {
       fiobj_str_write(url_tmp, args.address.data, args.address.len);
@@ -1076,11 +1088,19 @@ intptr_t iodine_ws_connect(iodine_connection_args_s args) {
     args.url = fiobj_obj2cstr(url_tmp);
   }
 
+#ifdef __MINGW32__
+  intptr_t uuid = http_connect(
+      args.url.data, (is_unix_socket ? args.address.data : NULL),
+      .udata = request_data_create(&args),
+      .on_response = ws_client_http_connected,
+      .on_finish = ws_client_http_connection_finished);
+#else
   intptr_t uuid = http_connect(
       args.url.data, (is_unix_socket ? args.address.data : NULL),
       .udata = request_data_create(&args),
       .on_response = ws_client_http_connected,
       .on_finish = ws_client_http_connection_finished, .tls = args.tls);
+#endif
   fiobj_free(url_tmp);
   return uuid;
 }

--- a/ext/iodine/iodine_http.c
+++ b/ext/iodine/iodine_http.c
@@ -12,11 +12,15 @@ Feel free to copy, use and enjoy according to the license provided.
 #include <ruby/io.h>
 // #include "iodine_websockets.h"
 
+#ifndef __MINGW32__
 #include <arpa/inet.h>
+#endif
 #include <ctype.h>
 #include <stdlib.h>
 #include <string.h>
+#ifndef __MINGW32__
 #include <sys/socket.h>
+#endif
 
 /* *****************************************************************************
 Available Globals

--- a/ext/iodine/iodine_rack_io.c
+++ b/ext/iodine/iodine_rack_io.c
@@ -69,7 +69,11 @@ static rb_encoding *IodineBinaryEncoding;
 
 inline static http_s *get_handle(VALUE obj) {
   VALUE i = rb_ivar_get(obj, iodine_fd_var_id);
+#ifdef __MINGW32__
+  return (http_s *)NUM2ULL(i);
+#else
   return (http_s *)FIX2ULONG(i);
+#endif
 }
 
 /* *****************************************************************************
@@ -78,7 +82,11 @@ IO API
 
 static inline FIOBJ get_data(VALUE self) {
   VALUE i = rb_ivar_get(self, io_id);
+#ifdef __MINGW32__
+  return (FIOBJ)NUM2ULL(i);
+#else
   return (FIOBJ)FIX2ULONG(i);
+#endif
 }
 
 static VALUE rio_rewind(VALUE self) {

--- a/ext/iodine/iodine_rack_io.c
+++ b/ext/iodine/iodine_rack_io.c
@@ -168,12 +168,6 @@ static VALUE rio_read(int argc, VALUE *argv, VALUE self) {
 static VALUE rio_close(VALUE self) {
   // FIOBJ io = get_data(self);
   // fiobj_free(io); // we don't call fiobj_dup, do we?
-#ifdef __MINGW32__
-  VALUE fd = rb_ivar_get(self, iodine_osffd_id);
-  int osffd = FIX2INT(fd);
-  if (osffd)
-    _close(osffd);
-#endif
   rb_ivar_set(self, io_id, INT2NUM(0));
   (void)self;
   return Qnil;
@@ -214,12 +208,10 @@ static VALUE rio_get_io(int argc, VALUE *argv, VALUE self) {
   // hijack the IO object
   intptr_t uuid = http_hijack(h, NULL);
 #ifdef __MINGW32__
-  SOCKET handle = fio_handle4fd(fio_uuid2fd(uuid));
-  int osffd = _open_osfhandle((intptr_t)handle, _O_RDWR);
+  int osffd = fio_osffd4fd(fio_uuid2fd(uuid));
   if (osffd == -1)
     return Qfalse;
   VALUE fd = INT2FIX(osffd);
-  rb_ivar_set(self, iodine_osffd_id, fd);
 #else
   VALUE fd = INT2FIX(fio_uuid2fd(uuid));
 #endif

--- a/ext/iodine/iodine_tcp.c
+++ b/ext/iodine/iodine_tcp.c
@@ -209,10 +209,17 @@ Returns the handler object used.
 intptr_t iodine_tcp_listen(iodine_connection_args_s args) {
   // clang-format on
   IodineStore.add(args.handler);
+#ifdef __MINGW32__
+  return fio_listen(.port = args.port.data, .address = args.address.data,
+                    .on_open = iodine_tcp_on_open,
+                    .on_finish = iodine_tcp_on_finish,
+                    .udata = (void *)args.handler);
+#else
   return fio_listen(.port = args.port.data, .address = args.address.data,
                     .on_open = iodine_tcp_on_open,
                     .on_finish = iodine_tcp_on_finish, .tls = args.tls,
                     .udata = (void *)args.handler);
+#endif
 }
 
 // clang-format off
@@ -238,10 +245,17 @@ Returns the handler object used.
 intptr_t iodine_tcp_connect(iodine_connection_args_s args){
   // clang-format on
   IodineStore.add(args.handler);
+#ifdef __MINGW32__
+  return fio_connect(.port = args.port.data, .address = args.address.data,
+                     .on_connect = iodine_tcp_on_connect,
+                     .on_fail = iodine_tcp_on_fail, .timeout = args.ping,
+                     .udata = (void *)args.handler);
+#else
   return fio_connect(.port = args.port.data, .address = args.address.data,
                      .on_connect = iodine_tcp_on_connect, .tls = args.tls,
                      .on_fail = iodine_tcp_on_fail, .timeout = args.ping,
                      .udata = (void *)args.handler);
+#endif
 }
 
 // clang-format off

--- a/ext/iodine/iodine_tls.c
+++ b/ext/iodine/iodine_tls.c
@@ -1,3 +1,10 @@
+#ifdef __MINGW32__
+// make pedantic compiler happy
+typedef struct {
+  int bogus;
+} bogus_s;
+
+#else
 #include <ruby.h>
 
 #include <fio.h>
@@ -251,3 +258,4 @@ void iodine_init_tls(void) {
 #endif
 }
 #undef IODINE_MAKE_SYM
+#endif

--- a/ext/iodine/mustache_parser.h
+++ b/ext/iodine/mustache_parser.h
@@ -28,6 +28,10 @@ Feel free to copy, use and enjoy according to the license provided.
 #include <sys/stat.h>
 #include <sys/types.h>
 
+#ifdef __MINGW32__
+ssize_t pread(int, void*, size_t, off_t);
+#endif
+
 #if !defined(__GNUC__) && !defined(__clang__) && !defined(FIO_GNUC_BYPASS)
 #define __attribute__(...)
 #define __has_include(...) 0

--- a/ext/iodine/websockets.c
+++ b/ext/iodine/websockets.c
@@ -17,7 +17,9 @@ Feel free to copy, use and enjoy according to the license provided.
 #include <http.h>
 #include <http_internal.h>
 
+#ifndef __MINGW32__
 #include <arpa/inet.h>
+#endif
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -26,7 +28,7 @@ Feel free to copy, use and enjoy according to the license provided.
 
 #include <websocket_parser.h>
 
-#if !defined(__BIG_ENDIAN__) && !defined(__LITTLE_ENDIAN__)
+#if !defined(__BIG_ENDIAN__) && !defined(__LITTLE_ENDIAN__) && !defined(__MINGW32__)
 #include <endian.h>
 #if !defined(__BIG_ENDIAN__) && !defined(__LITTLE_ENDIAN__) &&                 \
     __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
@@ -71,6 +73,7 @@ struct buffer_s create_ws_buffer(ws_s *owner) {
   struct buffer_s buff;
   buff.size = WS_INITIAL_BUFFER_SIZE;
   buff.data = malloc(buff.size);
+  FIO_ASSERT_ALLOC(buff.data);
   return buff;
 }
 
@@ -79,7 +82,6 @@ struct buffer_s resize_ws_buffer(ws_s *owner, struct buffer_s buff) {
   void *tmp = realloc(buff.data, buff.size);
   if (!tmp) {
     free_ws_buffer(owner, buff);
-    buff.data = NULL;
     buff.size = 0;
   }
   buff.data = tmp;
@@ -174,6 +176,7 @@ static void websocket_on_protocol_ping(void *ws_p, void *msg_, uint64_t len) {
   ws_s *ws = ws_p;
   if (msg_) {
     void *buff = malloc(len + 16);
+    FIO_ASSERT_ALLOC(buff);
     len = (((ws_s *)ws)->is_client
                ? websocket_client_wrap(buff, msg_, len, 10, 1, 1, 0)
                : websocket_server_wrap(buff, msg_, len, 10, 1, 1, 0));
@@ -305,6 +308,7 @@ Create/Destroy the websocket object
 static ws_s *new_websocket(intptr_t uuid) {
   // allocate the protocol object
   ws_s *ws = malloc(sizeof(*ws));
+  FIO_ASSERT_ALLOC(ws);
   *ws = (ws_s){
       .protocol.ping = ws_ping,
       .protocol.on_data = on_data_first,
@@ -330,7 +334,6 @@ static void destroy_ws(ws_s *ws) {
 void websocket_attach(intptr_t uuid, http_settings_s *http_settings,
                       websocket_settings_s *args, void *data, size_t length) {
   ws_s *ws = new_websocket(uuid);
-  FIO_ASSERT_ALLOC(ws);
   // we have an active websocket connection - prep the connection buffer
   ws->buffer = create_ws_buffer(ws);
   // Setup ws callbacks
@@ -383,6 +386,7 @@ static void websocket_write_impl(intptr_t fd, void *data, size_t len, char text,
                                  char first, char last, char client) {
   if (len <= WS_MAX_FRAME_SIZE) {
     void *buff = fio_malloc(len + 16);
+    FIO_ASSERT_ALLOC(buff);
     len = (client ? websocket_client_wrap(buff, data, len, (text ? 1 : 2),
                                           first, last, 0)
                   : websocket_server_wrap(buff, data, len, (text ? 1 : 2),

--- a/iodine.gemspec
+++ b/iodine.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.requirements << 'Ruby >= 2.3.8 (Ruby EOL).'
   spec.requirements << 'Ruby >= 2.5.0 recommended.'
   spec.requirements << 'TLS requires OpenSSL >= 1.1.0.'
-  spec.requirements << 'Or Windows with Ruby >= 3.0.0 nuild with MingW and MingW as compiler.'
+  spec.requirements << 'Or Windows with Ruby >= 3.0.0 build with MingW and MingW as compiler.'
 
   # spec.add_development_dependency 'bundler', '>= 1.10', '< 2.0'
   spec.add_development_dependency 'rake', '~> 13.0', '< 14.0'

--- a/iodine.gemspec
+++ b/iodine.gemspec
@@ -9,8 +9,8 @@ Gem::Specification.new do |spec|
   spec.authors       = ['Boaz Segev']
   spec.email         = ['bo@plezi.io']
 
-  spec.summary       = 'iodine - a fast HTTP / Websocket Server with Pub/Sub support, optimized for Ruby MRI on Linux / BSD'
-  spec.description   = 'A fast HTTP / Websocket Server with built-in Pub/Sub support (with or without Redis), static file support and many other features, optimized for Ruby MRI on Linux / BSD / macOS'
+  spec.summary       = 'iodine - a fast HTTP / Websocket Server with Pub/Sub support, optimized for Ruby MRI on Linux / BSD / Windows'
+  spec.description   = 'A fast HTTP / Websocket Server with built-in Pub/Sub support (with or without Redis), static file support and many other features, optimized for Ruby MRI on Linux / BSD / macOS / Windows'
   spec.homepage      = 'https://github.com/boazsegev/iodine'
   spec.license       = 'MIT'
 
@@ -35,7 +35,8 @@ Gem::Specification.new do |spec|
   spec.requirements << 'An updated C compiler.'
   spec.requirements << 'Ruby >= 2.3.8 (Ruby EOL).'
   spec.requirements << 'Ruby >= 2.5.0 recommended.'
-  spec.requirements << 'TLS requires OpenSSL >= 1.1.0'
+  spec.requirements << 'TLS requires OpenSSL >= 1.1.0.'
+  spec.requirements << 'Or Windows with Ruby >= 3.0.0 nuild with MingW and MingW as compiler.'
 
   # spec.add_development_dependency 'bundler', '>= 1.10', '< 2.0'
   spec.add_development_dependency 'rake', '~> 13.0', '< 14.0'

--- a/iodine.gemspec
+++ b/iodine.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.requirements << 'TLS requires OpenSSL >= 1.1.0'
 
   # spec.add_development_dependency 'bundler', '>= 1.10', '< 2.0'
-  spec.add_development_dependency 'rake', '~> 12.0', '< 13.0'
+  spec.add_development_dependency 'rake', '~> 13.0', '< 14.0'
   spec.add_development_dependency 'minitest', '>=5', '< 6.0'
   spec.add_development_dependency 'rspec', '>=3.9.0', '< 4.0'
   spec.add_development_dependency 'spec', '>=5.3.0', '< 6.0'

--- a/spec/support/iodine_server.rb
+++ b/spec/support/iodine_server.rb
@@ -36,6 +36,9 @@ module Spec
             sleep 0.1
             Socket.tcp('localhost', server_port, connect_timeout: 1) {}
             break
+          rescue Errno::ETIMEDOUT
+            raise "Could not start iodine, please check spec/log/test.log for more info" if tries > 10
+            tries += 1
           rescue Errno::ECONNREFUSED
             raise "Could not start iodine, please check spec/log/test.log for more info" if tries > 10
             tries += 1
@@ -46,7 +49,11 @@ module Spec
       def start_iodine_with_app(name, **opts)
         filename = "spec/support/apps/#{name}.ru"
         raise "test rack file (#{name}) does not exist" unless File.exist?(filename)
-        cmd = "#{Gem.win_platform? ? 'bundle.cmd' : 'bundle'} exec exe/iodine -w 1 -t 1 -p #{server_port}".dup
+        if Gem.win_platform?
+          cmd = "bundle exec ruby exe/iodine -w 1 -t 1 -p #{server_port}".dup
+        else
+          cmd = "bundle exec exe/iodine -w 1 -t 1 -p #{server_port}".dup
+        end
         cmd += " -V 5 -log" if opts[:verbose]
         pid = spawn_with_test_log("#{cmd} #{filename}", **opts)
         wait_until_iodine_ready
@@ -60,7 +67,12 @@ module Spec
           yield if block_given?
         ensure
           if !pid.nil?
-            Process.kill 'SIGINT', pid
+            if Gem.win_platform?
+              # SIGINT or SIGILL are unreliable on Windows, try native taskkill first
+              Process.kill('KILL', pid) unless system("taskkill /f /t /pid #{pid} >NUL 2>NUL")
+            else
+              Process.kill 'SIGINT', pid
+            end
             Process.wait pid
           end
         end

--- a/spec/support/iodine_server.rb
+++ b/spec/support/iodine_server.rb
@@ -1,4 +1,5 @@
 require 'http'
+require 'bundler'
 
 module Spec
   module Support
@@ -18,7 +19,7 @@ module Spec
       def spawn_with_test_log(cmd, verbose: ENV.key?('VERBOSE'))
         test_log = verbose ? STDERR : File.open('spec/log/test.log', 'a+')
 
-        Bundler.with_clean_env do
+        Bundler.with_unbundled_env do
           Process.spawn(cmd, out: test_log, err: test_log)
         end
       end
@@ -45,7 +46,7 @@ module Spec
       def start_iodine_with_app(name, **opts)
         filename = "spec/support/apps/#{name}.ru"
         raise "test rack file (#{name}) does not exist" unless File.exist?(filename)
-        cmd = "bundle exec exe/iodine -w 1 -t 1 -p #{server_port}".dup
+        cmd = "#{Gem.win_platform? ? 'bundle.cmd' : 'bundle'} exec exe/iodine -w 1 -t 1 -p #{server_port}".dup
         cmd += " -V 5 -log" if opts[:verbose]
         pid = spawn_with_test_log("#{cmd} #{filename}", **opts)
         wait_until_iodine_ready


### PR DESCRIPTION
specs pass, needs cleanup a bit, and faciol.io PR116 (once fixed)
```
install -c tmp/x64-mingw32/iodine/3.0.1/iodine.so lib/iodine/iodine.so
cp tmp/x64-mingw32/iodine/3.0.1/iodine.so tmp/x64-mingw32/stage/lib/iodine/iodine.so
C:/Ruby30-x64/bin/ruby.exe -I'C:/Ruby30-x64/lib/ruby/gems/3.0.0/gems/rspec-support-3.10.2/lib';'C:/Ruby30-x64/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/lib' 'C:/Ruby30-x64/lib/ruby/gems/3.0.0/gems/rspec-core-3.10.1/exe/rspec' --pattern 'spec/**{,/*/**}/*_spec.rb'

Randomized with seed 49840
..................

Top 10 slowest examples (24.09 seconds, 59.0% of total time):
  Last-Modified Header overrides the header if the value is set to nil
    2.43 seconds ./spec/integration/last_modified_header_spec.rb:19
  Transfer-Encoding: chunked when the request is not chunked returns the correct body
    2.42 seconds ./spec/integration/chunked_encoding_spec.rb:18
  Transfer-Encoding: chunked when the header is downcased returns the correct Content-Length
    2.41 seconds ./spec/integration/chunked_encoding_spec.rb:25
  Transfer-Encoding: chunked when the request is chunked returns the correct body
    2.41 seconds ./spec/integration/chunked_encoding_spec.rb:18
  Transfer-Encoding: chunked when the body size is long (includes Content-Length) returns the correct Content-Length
    2.41 seconds ./spec/integration/chunked_encoding_spec.rb:25
  Transfer-Encoding: chunked when the body size is long and evenly chunked returns the correct Content-Length
    2.41 seconds ./spec/integration/chunked_encoding_spec.rb:25
  Transfer-Encoding: chunked when the header is downcased returns the correct body
    2.4 seconds ./spec/integration/chunked_encoding_spec.rb:18
  Transfer-Encoding: chunked when the request is not chunked returns the correct Content-Length
    2.4 seconds ./spec/integration/chunked_encoding_spec.rb:25
  Last-Modified Header is parseable by Time#httpdate
    2.4 seconds ./spec/integration/last_modified_header_spec.rb:4
  Transfer-Encoding: chunked when the request is chunked returns the correct Content-Length
    2.4 seconds ./spec/integration/chunked_encoding_spec.rb:25

Top 3 slowest example groups:
  Last-Modified Header
    2.41 seconds average (7.23 seconds / 3 examples) ./spec/integration/last_modified_header_spec.rb:3
  Transfer-Encoding: chunked
    2.4 seconds average (33.6 seconds / 14 examples) ./spec/integration/chunked_encoding_spec.rb:2
  Iodine
    0.00758 seconds average (0.00758 seconds / 1 example) ./spec/unit/iodine_spec.rb:1

Finished in 40.87 seconds (files took 1.36 seconds to load)
18 examples, 0 failures

Randomized with seed 49840
```