### PR TITLE
Don't initialize `SERVER_PORT` in ENV to empty String

### DIFF
--- a/ext/iodine/iodine_http.c
+++ b/ext/iodine/iodine_http.c
@@ -365,7 +365,6 @@ static inline VALUE copy2env(iodine_http_request_handle_s *handle) {
   if (*pos == 0) {
     rb_hash_aset(env, SERVER_NAME,
                  rb_enc_str_new(tmp.data, tmp.len, IodineBinaryEncoding));
-    rb_hash_aset(env, SERVER_PORT, QUERY_ESTRING);
   } else {
     rb_hash_aset(
         env, SERVER_NAME,
@@ -865,7 +864,6 @@ static void initialize_env_template(void) {
   rb_hash_aset(env_template_no_upgrade, REMOTE_ADDR, QUERY_STRING);
   rb_hash_aset(env_template_no_upgrade, REQUEST_METHOD, QUERY_STRING);
   rb_hash_aset(env_template_no_upgrade, SERVER_NAME, QUERY_STRING);
-  rb_hash_aset(env_template_no_upgrade, SERVER_PORT, QUERY_ESTRING);
   rb_hash_aset(env_template_no_upgrade, SERVER_PROTOCOL, QUERY_STRING);
 
   /* WebSocket upgrade support */


### PR DESCRIPTION
The Rack specification states that if `SERVER_PORT` is present,
it must be a numeric value.

When initializing the Hash, the `SERVER_PORT` key is set, but
never filled in.

Closes #107 

I'm not sure if this is the most optimal solution but I wanted to offer something.