### PR TITLE
Support X-Sendfile in response to a POST request

### DIFF
--- a/ext/iodine/http.c
+++ b/ext/iodine/http.c
@@ -571,6 +571,8 @@ found_file:
       http_set_header(h, HTTP_HEADER_CONTENT_LENGTH, fiobj_num_new(length));
       http_finish(h);
       return 0;
+    } else if (!strncasecmp("post", s.data, 4)) {
+      goto open_file;
     }
     break;
   }


### PR DESCRIPTION
I don't see why this shouldn't be supported, NGINX and Apache do allow it.