### PR TITLE
support HTTP code 418

### DIFF
--- a/ext/iodine/http.c
+++ b/ext/iodine/http.c
@@ -2696,6 +2696,7 @@ fio_str_info_s http_status2str(uintptr_t status) {
       HTTP_SET_STATUS_STR(415, "Unsupported Media Type"),
       HTTP_SET_STATUS_STR(416, "Range Not Satisfiable"),
       HTTP_SET_STATUS_STR(417, "Expectation Failed"),
+      HTTP_SET_STATUS_STR(418, "I'm a teapot"),
       HTTP_SET_STATUS_STR(421, "Misdirected Request"),
       HTTP_SET_STATUS_STR(422, "Unprocessable Entity"),
       HTTP_SET_STATUS_STR(423, "Locked"),


### PR DESCRIPTION
418 I'm a teapot was a result of RFC2324 which was an April 1 RFC. See rfc9110 for more detailed information.

It is still very useful to allow for creating easter eggs and generally make life more fun. And as we all know, boring is worse than death.

This is only my personal opinion, but anyway, it is the only correct opinion.

My specific use case is my websocket echo server that does not process HTTP requests and should warn users making HTTP requests that this is not the intended purpose of the service.

Presently it uses 405 which is probably reasonable but **boring**. See https://github.com/akostadinov/websocket-echo-io/blob/0.1.0/lib/websocket/echo/io/server.rb#L26

/fixes #144