### PR TITLE
Rack 3 compatibility

### DIFF
--- a/lib/rack/handler/iodine.rb
+++ b/lib/rack/handler/iodine.rb
@@ -24,14 +24,14 @@ module Iodine
   end
 end
 
+ENV['RACK_HANDLER'] ||= 'iodine'
+
 # rackup was removed in Rack 3, it is now a separate gem
 if Object.const_defined? :Rackup
   ENV['RACKUP_HANDLER'] ||= 'iodine'
 
   ::Rackup::Handler.register(:iodine, Iodine::Rack) if defined?(::Rackup::Handler)
 elsif Object.const_defined?(:Rack) && Rack::RELEASE < '3'
-  ENV['RACK_HANDLER'] ||= 'iodine'
-
   begin
     ::Rack::Handler.register('iodine', 'Iodine::Rack') if defined?(::Rack::Handler)
     ::Rack::Handler.register('Iodine', 'Iodine::Rack') if defined?(::Rack::Handler)

--- a/lib/rack/handler/iodine.rb
+++ b/lib/rack/handler/iodine.rb
@@ -24,10 +24,19 @@ module Iodine
   end
 end
 
-ENV['RACK_HANDLER'] ||= 'iodine'
+# rackup was removed in Rack 3, it is now a separate gem
+if Object.const_defined? :Rackup
+  ENV['RACKUP_HANDLER'] ||= 'iodine'
 
-begin
-  ::Rack::Handler.register('iodine', 'Iodine::Rack') if defined?(::Rack::Handler)
-  ::Rack::Handler.register('Iodine', 'Iodine::Rack') if defined?(::Rack::Handler)
-rescue StandardError
+  ::Rackup::Handler.register(:iodine, Iodine::Rack) if defined?(::Rackup::Handler)
+elsif Object.const_defined?(:Rack) && Rack::RELEASE < '3'
+  ENV['RACK_HANDLER'] ||= 'iodine'
+
+  begin
+    ::Rack::Handler.register('iodine', 'Iodine::Rack') if defined?(::Rack::Handler)
+    ::Rack::Handler.register('Iodine', 'Iodine::Rack') if defined?(::Rack::Handler)
+  rescue StandardError
+  end
+else
+  raise "You must install the rackup gem when using Rack 3"
 end

--- a/lib/rack/handler/iodine.rb
+++ b/lib/rack/handler/iodine.rb
@@ -37,6 +37,4 @@ elsif Object.const_defined?(:Rack) && Rack::RELEASE < '3'
     ::Rack::Handler.register('Iodine', 'Iodine::Rack') if defined?(::Rack::Handler)
   rescue StandardError
   end
-else
-  raise "You must install the rackup gem when using Rack 3"
 end


### PR DESCRIPTION
Rack 3 now has Rackup as a separate gem: https://github.com/rack/rack/pull/1937

This PR detects whether the Rackup namespace is present, and supports both Rack 2 and Rack 3.

The conditional logic for this PR follows the pattern and rationale used here. https://github.com/puma/puma/pull/3061

